### PR TITLE
Moved utility functions for mTLS policies

### DIFF
--- a/pkg/vetter/util/mtlspolicy/authPolicy.go
+++ b/pkg/vetter/util/mtlspolicy/authPolicy.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"errors"
+
+	authv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	istioauthv1alpha1 "istio.io/api/authentication/v1alpha1"
+)
+
+type policiesByNamespaceMap map[string][]*authv1alpha1.Policy
+type policiesByNameMap map[string][]*authv1alpha1.Policy
+type policiesByNamespaceNameMap map[string]policiesByNameMap
+type policiesByPortMap map[uint32][]*authv1alpha1.Policy
+type policiesByNamePortMap map[string]policiesByPortMap
+type policiesByNamespaceNamePortMap map[string]policiesByNamePortMap
+
+// AuthPolicies holds maps of Istio authorization policies by port, name, namespace
+type AuthPolicies struct {
+	namespace policiesByNamespaceMap
+	name      policiesByNamespaceNameMap
+	port      policiesByNamespaceNamePortMap
+}
+
+// NewAuthPolicies initializes the maps for an AuthPolicies to be loaded by
+// LoadAuthPolicies
+func NewAuthPolicies() *AuthPolicies {
+	return &AuthPolicies{
+		namespace: make(policiesByNamespaceMap),
+		name:      make(policiesByNamespaceNameMap),
+		port:      make(policiesByNamespaceNamePortMap),
+	}
+}
+
+// AddByNamespace adds a Policy to the AuthPolicies namespace map
+func (ap *AuthPolicies) AddByNamespace(namespace string, policy *authv1alpha1.Policy) {
+	n := ap.namespace[namespace]
+	ap.namespace[namespace] = append(n, policy)
+}
+
+// AddByName adds a Policy to the AuthPolicies name map
+func (ap *AuthPolicies) AddByName(s Service, policy *authv1alpha1.Policy) {
+	namespace, ok := ap.name[s.Namespace]
+	if !ok {
+		namespace = make(policiesByNameMap)
+		ap.name[s.Namespace] = namespace
+	}
+	name, _ := namespace[s.Name]
+	namespace[s.Name] = append(name, policy)
+}
+
+// AddByPort adds a Policy to the AuthPolicies port map
+func (ap *AuthPolicies) AddByPort(s Service, port uint32, policy *authv1alpha1.Policy) {
+	namespace, ok := ap.port[s.Namespace]
+	if !ok {
+		namespace = make(policiesByNamePortMap)
+		ap.port[s.Namespace] = namespace
+	}
+	name, ok := namespace[s.Name]
+	if !ok {
+		name = make(policiesByPortMap)
+		namespace[s.Name] = name
+	}
+	p, _ := name[port]
+	name[port] = append(p, policy)
+}
+
+// ByNamespace is passed a namespace and returns the Policy in the AuthPolicies
+// namespace map for that namespace
+func (ap *AuthPolicies) ByNamespace(namespace string) []*authv1alpha1.Policy {
+	n, ok := ap.namespace[namespace]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	return n
+}
+
+// ByName is passed a Service and returns the Policy in the AuthPolicies
+// namespace map for the name of that Service
+func (ap *AuthPolicies) ByName(s Service) []*authv1alpha1.Policy {
+	ns, ok := ap.name[s.Namespace]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	n, ok := ns[s.Name]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	return n
+}
+
+// ByPort is passed a Service and a port number and returns the Policy in the
+// AuthPolicies port map for that port number
+func (ap *AuthPolicies) ByPort(s Service, port uint32) []*authv1alpha1.Policy {
+	ns, ok := ap.port[s.Namespace]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	n, ok := ns[s.Name]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	p, ok := n[port]
+	if !ok {
+		return []*authv1alpha1.Policy{}
+	}
+	return p
+}
+
+// AuthPolicyIsMtls returns true if the passed Policy has mTLS enabled
+func AuthPolicyIsMtls(policy *authv1alpha1.Policy) bool {
+	peers := policy.Spec.GetPeers()
+	if peers == nil {
+		return false
+	}
+	for _, peer := range peers {
+		// mTLS is "on" if there is an mTLS peer entry, even if it is nil.
+		// so e.g.:
+		//   peers:
+		//   - mtls: null
+		// We can't use .GetMtls(), we need to attempt the cast ourselves, because
+		// .GetMtls() will return nil if the peer isn't mTLS AND if the peer is an
+		// empty mTLS, and we won't be able to distinguish.
+		_, ok := peer.GetParams().(*istioauthv1alpha1.PeerAuthenticationMethod_Mtls)
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TLSByPort walks through Policies at the port level and
+// returns true if the Policy found has mTLS enabled
+func (ap *AuthPolicies) TLSByPort(s Service, port uint32) (bool, *authv1alpha1.Policy, error) {
+	policies := ap.ByPort(s, port)
+	if len(policies) > 1 {
+		// TODO: If all the policies are the same, does it work?
+		return false, nil, errors.New("Conflicting policies for port")
+	}
+	if len(policies) == 1 {
+		return AuthPolicyIsMtls(policies[0]), policies[0], nil
+	}
+	// TODO: Walk the next tier?
+	return false, nil, errors.New("No policy for port")
+}
+
+// TLSByName walks through Policies at the name level and
+// returns true if the Policy found has mTLS enabled
+func (ap *AuthPolicies) TLSByName(s Service) (bool, *authv1alpha1.Policy, error) {
+	policies := ap.ByName(s)
+	if len(policies) > 1 {
+		// TODO: If all the policies are the same, does it work?
+		return false, nil, errors.New("Conflicting policies for service by name")
+	}
+	if len(policies) == 1 {
+		return AuthPolicyIsMtls(policies[0]), policies[0], nil
+	}
+	// TODO: Walk the next tier?
+	return false, nil, errors.New("No policy for service by name")
+}
+
+// TLSByNamespace walks through Policies at the namespace level and
+// returns true if the Policy found has mTLS enabled
+func (ap *AuthPolicies) TLSByNamespace(s Service) (bool, *authv1alpha1.Policy, error) {
+	policies := ap.ByNamespace(s.Namespace)
+	if len(policies) > 1 {
+		// TODO: If all the policies are the same, does it work?
+		return false, nil, errors.New("Conflicting policies for service by namespace")
+	}
+	if len(policies) == 1 {
+		return AuthPolicyIsMtls(policies[0]), policies[0], nil
+	}
+	return false, nil, errors.New("No policy for service by namespace")
+}
+
+// LoadAuthPolicies is passed a list of Policies and returns an AuthPolicies
+// with each of the Policies mapped by port, name, and namespace
+func LoadAuthPolicies(policies []*authv1alpha1.Policy) (*AuthPolicies, error) {
+	loaded := NewAuthPolicies()
+	for _, policy := range policies {
+		targets := policy.Spec.GetTargets()
+		if targets == nil || len(targets) == 0 {
+			// No targets: this is a namespace-wide policy.
+			if policy.Name != "default" {
+				// This policy is invalid according to docs.
+				continue
+			}
+			loaded.AddByNamespace(policy.Namespace, policy)
+			continue
+		}
+
+		// Policy has targets.
+		for _, target := range targets {
+			name := target.GetName()
+			if name == "" {
+				// According to docs, this is invalid.
+				continue
+			}
+			s := Service{Name: name, Namespace: policy.Namespace}
+			ports := target.GetPorts()
+			if ports == nil || len(ports) == 0 {
+				// This policy applies to a service by name
+				loaded.AddByName(s, policy)
+				continue
+			}
+
+			for _, port := range ports {
+				n := port.GetNumber()
+				if n == 0 {
+					continue
+				}
+				loaded.AddByPort(s, n, policy)
+			}
+		}
+	}
+	return loaded, nil
+}

--- a/pkg/vetter/util/mtlspolicy/authPolicy_test.go
+++ b/pkg/vetter/util/mtlspolicy/authPolicy_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	authv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	istioauthv1alpha1 "istio.io/api/authentication/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	apDefaultOn = &authv1alpha1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "barNs",
+		},
+		Spec: authv1alpha1.PolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Targets: []*istioauthv1alpha1.TargetSelector{},
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+
+	apFooOn = &authv1alpha1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apFooOn",
+			Namespace: "default",
+		},
+		Spec: authv1alpha1.PolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Targets: []*istioauthv1alpha1.TargetSelector{
+					&istioauthv1alpha1.TargetSelector{
+						Name: "foo",
+					},
+				},
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+
+	apFooOff = &authv1alpha1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apFooOff",
+			Namespace: "default",
+		},
+		Spec: authv1alpha1.PolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Targets: []*istioauthv1alpha1.TargetSelector{
+					&istioauthv1alpha1.TargetSelector{
+						Name: "foo",
+					},
+				},
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{},
+				},
+			},
+		},
+	}
+
+	apFooBarOn = &authv1alpha1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apFooBarOn",
+			Namespace: "default",
+		},
+		Spec: authv1alpha1.PolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Targets: []*istioauthv1alpha1.TargetSelector{
+					&istioauthv1alpha1.TargetSelector{
+						Name: "foo",
+					},
+					&istioauthv1alpha1.TargetSelector{
+						Name: "bar",
+					},
+				},
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+
+	apFooPortsBarOn = &authv1alpha1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apFooPortsBarOn",
+			Namespace: "default",
+		},
+		Spec: authv1alpha1.PolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Targets: []*istioauthv1alpha1.TargetSelector{
+					&istioauthv1alpha1.TargetSelector{
+						Name: "foo",
+						Ports: []*istioauthv1alpha1.PortSelector{
+							&istioauthv1alpha1.PortSelector{
+								Port: &istioauthv1alpha1.PortSelector_Number{8443},
+							},
+						},
+					},
+					&istioauthv1alpha1.TargetSelector{
+						Name: "bar",
+					},
+				},
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+)
+var _ = Describe("LoadAuthPolicies", func() {
+	It("should load policies", func() {
+		loaded, err := LoadAuthPolicies([]*authv1alpha1.Policy{
+			apDefaultOn,
+			apFooOn,
+			apFooOff,
+			apFooBarOn,
+			apFooPortsBarOn,
+		})
+		Expect(err).To(Succeed())
+		foo := Service{Namespace: "default", Name: "foo"}
+		bar := Service{Namespace: "default", Name: "bar"}
+		Expect(loaded.ByNamespace("barNs")).To(Equal([]*authv1alpha1.Policy{apDefaultOn}))
+		Expect(loaded.ByNamespace("default")).To(Equal([]*authv1alpha1.Policy{}))
+
+		Expect(loaded.ByName(foo)).To(Equal([]*authv1alpha1.Policy{
+			apFooOn,
+			apFooOff,
+			apFooBarOn,
+			// no apFooPortsBarOn because that is only for foo:8443, not foo
+		}))
+		Expect(loaded.ByName(bar)).To(Equal([]*authv1alpha1.Policy{
+			apFooBarOn,
+			// apFooPortsBarOn because that is for bar (not bar:8443)
+			apFooPortsBarOn,
+		}))
+
+		Expect(loaded.ByPort(foo, 8443)).To(Equal([]*authv1alpha1.Policy{apFooPortsBarOn}))
+		Expect(loaded.ByPort(foo, 1000)).To(Equal([]*authv1alpha1.Policy{}))
+		Expect(loaded.ByPort(bar, 8443)).To(Equal([]*authv1alpha1.Policy{}))
+	})
+})
+
+var _ = Describe("AuthPolicyIsMtls", func() {
+	It("should evaluate no-mtls-peer as false", func() {
+		Expect(AuthPolicyIsMtls(apFooOff)).To(BeFalse())
+	})
+	It("should evaluate empty-mtls-peer as true", func() {
+		Expect(AuthPolicyIsMtls(apFooPortsBarOn)).To(BeTrue())
+	})
+})

--- a/pkg/vetter/util/mtlspolicy/destinationRule.go
+++ b/pkg/vetter/util/mtlspolicy/destinationRule.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"errors"
+
+	netv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	istionetv1alpha3 "istio.io/api/networking/v1alpha3"
+)
+
+// Destination Rules can have arbitrary PortTrafficPolicy; we don't want to
+// re-walk a destination rule to find the correct PortTrafficPolicy for the
+// particular port we're working on.  For ports, store both the
+// DestinationRule, and the PortTrafficPolicy inside that we care about for
+// this particular port.
+
+type destRulesByNamespaceMap map[string][]*netv1alpha3.DestinationRule
+type destRulesByNameMap map[string][]*netv1alpha3.DestinationRule
+type destRulesByNamespaceNameMap map[string]destRulesByNameMap
+type destRulesByPortMap map[uint32][]*PortDestRule
+type destRulesByNamePortMap map[string]destRulesByPortMap
+type destRulesByNamespaceNamePortMap map[string]destRulesByNamePortMap
+
+// DestRules holds maps of Istio destination rules by port, name, and namespace
+type DestRules struct {
+	// Destination rules must have a host specifier.  In Istio 0.8 they cannot be
+	// cluster-wide, but they can be namespace wide
+	// (*.namespace.svc.cluster.local)
+	namespace destRulesByNamespaceMap
+	name      destRulesByNamespaceNameMap
+	port      destRulesByNamespaceNamePortMap
+}
+
+// PortDestRule stores the Istio destination rule and port traffic policy for a port
+type PortDestRule struct {
+	Rule     *netv1alpha3.DestinationRule
+	PortRule *istionetv1alpha3.TrafficPolicy_PortTrafficPolicy
+}
+
+// NewDestRules initializes the maps for a DestRules to be loaded by
+// LoadDestRules
+func NewDestRules() *DestRules {
+	return &DestRules{
+		namespace: make(destRulesByNamespaceMap),
+		name:      make(destRulesByNamespaceNameMap),
+		port:      make(destRulesByNamespaceNamePortMap),
+	}
+}
+
+// AddByNamespace adds a Destination Rule to the DestRules namespace map
+func (dr *DestRules) AddByNamespace(namespace string, rule *netv1alpha3.DestinationRule) {
+	ns, _ := dr.namespace[namespace]
+	dr.namespace[namespace] = append(ns, rule)
+}
+
+// AddByName adds a Destination Rule to the DestRules name map
+func (dr *DestRules) AddByName(s Service, rule *netv1alpha3.DestinationRule) {
+	namespace, ok := dr.name[s.Namespace]
+	if !ok {
+		namespace = make(destRulesByNameMap)
+		dr.name[s.Namespace] = namespace
+	}
+	name, _ := namespace[s.Name]
+	namespace[s.Name] = append(name, rule)
+}
+
+// AddByPort adds a Destination Rule to the DestRules port map
+func (dr *DestRules) AddByPort(
+	s Service,
+	port uint32,
+	rule *netv1alpha3.DestinationRule,
+	portRule *istionetv1alpha3.TrafficPolicy_PortTrafficPolicy,
+) {
+	namespace, ok := dr.port[s.Namespace]
+	if !ok {
+		namespace = make(destRulesByNamePortMap)
+		dr.port[s.Namespace] = namespace
+	}
+	name, ok := namespace[s.Name]
+	if !ok {
+		name = make(destRulesByPortMap)
+		namespace[s.Name] = name
+	}
+	p, _ := name[port]
+	name[port] = append(p, &PortDestRule{Rule: rule, PortRule: portRule})
+}
+
+// ByNamespace is passed a namespace and returns the Destination Rule in the
+// DestRules namespace map for that namespace
+func (dr *DestRules) ByNamespace(namespace string) []*netv1alpha3.DestinationRule {
+	ns, ok := dr.namespace[namespace]
+	if !ok {
+		return []*netv1alpha3.DestinationRule{}
+	}
+	return ns
+}
+
+// ByName is passed a Service and returns the Destination Rule in the
+// DestRules name map for the name of that Service
+func (dr *DestRules) ByName(s Service) []*netv1alpha3.DestinationRule {
+	ns, ok := dr.name[s.Namespace]
+	if !ok {
+		return []*netv1alpha3.DestinationRule{}
+	}
+	res, ok := ns[s.Name]
+	if !ok {
+		return []*netv1alpha3.DestinationRule{}
+	}
+	return res
+}
+
+// ByPort is passed a Service and a port number and returns the Destination Rule
+// in the DestRules port map for that port number
+func (dr *DestRules) ByPort(s Service, port uint32) []*PortDestRule {
+	ns, ok := dr.port[s.Namespace]
+	if !ok {
+		return []*PortDestRule{}
+	}
+	n, ok := ns[s.Name]
+	if !ok {
+		return []*PortDestRule{}
+	}
+	res, ok := n[port]
+	if !ok {
+		return []*PortDestRule{}
+	}
+	return res
+}
+
+// ForEachByPort examines all Destination Rules for a Service and port number
+// based off of a PortDestRule that is passed
+func (dr *DestRules) ForEachByPort(cb func(s Service, port uint32, rule *PortDestRule)) {
+	for namespace, rulesForNamespace := range dr.port {
+		for name, rulesForName := range rulesForNamespace {
+			s := Service{Name: name, Namespace: namespace}
+			for port, rulesForPort := range rulesForName {
+				for _, rule := range rulesForPort {
+					cb(s, port, rule)
+				}
+			}
+		}
+	}
+}
+
+// ForEachByName examines all Destination Rules for a Service based off of a
+// Destination Rule that is passed
+func (dr *DestRules) ForEachByName(cb func(s Service, rule *netv1alpha3.DestinationRule)) {
+	for namespace, rulesForNamespace := range dr.name {
+		for name, rulesForName := range rulesForNamespace {
+			s := Service{Name: name, Namespace: namespace}
+			for _, rule := range rulesForName {
+				cb(s, rule)
+			}
+		}
+	}
+}
+
+// PortDestRuleIsMtls returns true if mTLS is enabled for the PortDestRule
+func PortDestRuleIsMtls(rule *PortDestRule) bool {
+	return rule.PortRule.GetTls().GetMode() == istionetv1alpha3.TLSSettings_ISTIO_MUTUAL
+}
+
+// DestRuleIsMtls returns true if mTLS is enabled for the Destination Rule
+func DestRuleIsMtls(rule *netv1alpha3.DestinationRule) bool {
+	return rule.Spec.GetTrafficPolicy().GetTls().GetMode() == istionetv1alpha3.TLSSettings_ISTIO_MUTUAL
+}
+
+// TLSByPort returns true if mTLS is enabled for the PortDestination rule of the
+// port number passed
+func (dr *DestRules) TLSByPort(s Service, port uint32) (bool, *PortDestRule, error) {
+	rules := dr.ByPort(s, port)
+	if len(rules) > 1 {
+		// TODO: If all the rules are the same, does it work?
+		return false, nil, errors.New("Conflicting rules for port")
+	}
+	if len(rules) == 1 {
+		return PortDestRuleIsMtls(rules[0]), rules[0], nil
+	}
+	// TODO: Walk the next tier?
+	return false, nil, errors.New("No rule for port")
+}
+
+// TLSByName returns true if mTLS is enabled for the Destination Rule
+func (dr *DestRules) TLSByName(s Service) (bool, *netv1alpha3.DestinationRule, error) {
+	rules := dr.ByName(s)
+	if len(rules) > 1 {
+		// TODO: If all the rules are the same, does it work?
+		return false, nil, errors.New("Conflicting rules for name")
+	}
+	if len(rules) == 1 {
+		return DestRuleIsMtls(rules[0]), rules[0], nil
+	}
+	// TODO: Walk the next tier?
+	return false, nil, errors.New("No rule for name")
+}
+
+// LoadDestRules is passed a list of Destination Rules and returns a DestRules
+// with each of the Destination Rules mapped by port, name, and namespace
+func LoadDestRules(rules []*netv1alpha3.DestinationRule) (*DestRules, error) {
+	loaded := NewDestRules()
+	for _, r := range rules {
+		host := r.Spec.Host
+		if host == "" {
+			// Host is REQUIRED according to Istio so skip this invalid rule
+			continue
+		}
+		s, err := ServiceFromFqdn(host)
+		if err != nil || r.Spec.GetTrafficPolicy() == nil {
+			// Rule refers to a non-mesh service or has no TLS settings, skip.
+			continue
+		}
+		// Handle the top-level policy
+		if r.Spec.GetTrafficPolicy().GetTls() != nil {
+			if s.Name == "*" {
+				if s.Namespace == "*" {
+					// This isn't allowed in Istio 0.8
+					// TODO(andrew): Check that it doesn't work in 0.8.
+					continue
+				}
+				loaded.AddByNamespace(s.Namespace, r)
+			} else {
+				loaded.AddByName(s, r)
+			}
+		}
+
+		// For each port-level setting, handle the port specific overrides.
+		for _, pl := range r.Spec.GetTrafficPolicy().GetPortLevelSettings() {
+			if pl.Tls == nil || pl.Port == nil {
+				// Rule has no TLS settings or no selector, skip
+				continue
+			}
+			n := pl.GetPort().GetNumber()
+			if n == 0 {
+				continue
+			}
+			loaded.AddByPort(s, n, r, pl)
+		}
+	}
+	return loaded, nil
+}

--- a/pkg/vetter/util/mtlspolicy/destinationRule_test.go
+++ b/pkg/vetter/util/mtlspolicy/destinationRule_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metanetv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	netv1alpha3 "istio.io/api/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	drFooOn = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drFooOn",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					Tls: &netv1alpha3.TLSSettings{
+						Mode: netv1alpha3.TLSSettings_MUTUAL,
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+
+	drBarOff = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drBarOff",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "bar.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					Tls: &netv1alpha3.TLSSettings{
+						Mode: netv1alpha3.TLSSettings_DISABLE,
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+
+	drFooPortOnlyOn8443 = &netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+		Port: &netv1alpha3.PortSelector{
+			Port: &netv1alpha3.PortSelector_Number{8443},
+		},
+		Tls: &netv1alpha3.TLSSettings{
+			Mode: netv1alpha3.TLSSettings_MUTUAL,
+		},
+	}
+
+	drFooPortOnlyOn = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drFooPortOnlyOn",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					PortLevelSettings: []*netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+						drFooPortOnlyOn8443,
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+
+	drFooPortOnlyOff8443 = &netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+		Port: &netv1alpha3.PortSelector{
+			Port: &netv1alpha3.PortSelector_Number{8443},
+		},
+		Tls: &netv1alpha3.TLSSettings{
+			Mode: netv1alpha3.TLSSettings_DISABLE,
+		},
+	}
+
+	drFooPortOnlyOff = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drFooPortOnlyOff",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					PortLevelSettings: []*netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+						drFooPortOnlyOff8443,
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+
+	drDefaultNsOn = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drDefaultNsFooPortOnlyOn",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "*.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					Tls: &netv1alpha3.TLSSettings{
+						Mode: netv1alpha3.TLSSettings_DISABLE,
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+
+	// This would turn on mTLS for all services in default namespace but only
+	// on port 8443.  Weird, but allowed.
+	drDefaultNsFooPortOnlyOn = &metanetv1alpha3.DestinationRule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DestinationRule",
+			APIVersion: "networking.istio.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "drDefaultNsFooPortOnlyOn",
+			Namespace: "default",
+		},
+		Spec: metanetv1alpha3.DestinationRuleSpec{
+			DestinationRule: netv1alpha3.DestinationRule{
+				Host: "*.default.svc.cluster.local",
+				TrafficPolicy: &netv1alpha3.TrafficPolicy{
+					PortLevelSettings: []*netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+						&netv1alpha3.TrafficPolicy_PortTrafficPolicy{
+							Port: &netv1alpha3.PortSelector{
+								Port: &netv1alpha3.PortSelector_Number{8443},
+							},
+							Tls: &netv1alpha3.TLSSettings{
+								Mode: netv1alpha3.TLSSettings_MUTUAL,
+							},
+						},
+					},
+				},
+				Subsets: []*netv1alpha3.Subset{},
+			},
+		},
+	}
+)
+
+var _ = Describe("LoadDestRules", func() {
+	It("should load rules", func() {
+		loaded, err := LoadDestRules([]*metanetv1alpha3.DestinationRule{
+			drFooOn,
+			drBarOff,
+			drFooPortOnlyOn,
+			drDefaultNsOn,
+		})
+		Expect(err).To(Succeed())
+		Expect(loaded.ByNamespace("default")).To(Equal([]*metanetv1alpha3.DestinationRule{drDefaultNsOn}))
+		Expect(loaded.ByName(Service{Name: "foo", Namespace: "default"})).To(Equal([]*metanetv1alpha3.DestinationRule{drFooOn}))
+		Expect(loaded.ByName(Service{Name: "bar", Namespace: "default"})).To(Equal([]*metanetv1alpha3.DestinationRule{drBarOff}))
+		Expect(loaded.ByPort(Service{Name: "foo", Namespace: "default"}, 8443)).To(Equal([]*PortDestRule{
+			&PortDestRule{
+				Rule:     drFooPortOnlyOn,
+				PortRule: drFooPortOnlyOn8443,
+			},
+		}))
+	})
+})

--- a/pkg/vetter/util/mtlspolicy/mtlspolicy_suite_test.go
+++ b/pkg/vetter/util/mtlspolicy/mtlspolicy_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMtlspolicy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mtlspolicy Suite")
+}

--- a/pkg/vetter/util/mtlspolicy/util.go
+++ b/pkg/vetter/util/mtlspolicy/util.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
+)
+
+// Service is the necesary components of a kubernetes service to look at auth
+// policies and destination rules
+type Service struct {
+	Name      string
+	Namespace string
+}
+
+// ServiceFromFqdn validates a kubernetes FQDN and returns a service with the
+// name and namespace from a validated FQDN
+func ServiceFromFqdn(fqdn string) (Service, error) {
+	if !strings.HasSuffix(fqdn, util.KubernetesDomainSuffix) {
+		return Service{}, errors.New("FQDN suffix unrecognized")
+	}
+	front := strings.TrimSuffix(fqdn, util.KubernetesDomainSuffix)
+	parts := strings.Split(front, ".")
+	if len(parts) != 2 || len(parts[0]) < 1 || len(parts[1]) < 1 {
+		return Service{}, errors.New("FQDN does not have name and namespace")
+	}
+	return Service{Name: parts[0], Namespace: parts[1]}, nil
+}

--- a/pkg/vetter/util/mtlspolicy/util_test.go
+++ b/pkg/vetter/util/mtlspolicy/util_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceFromFqdn", func() {
+	It("should accept valid FQDNs", func() {
+		type passTc struct {
+			Fqdn    string
+			Service Service
+		}
+		passTestCases := []passTc{
+			passTc{
+				Fqdn:    "foo.default.svc.cluster.local",
+				Service: Service{Name: "foo", Namespace: "default"},
+			},
+			passTc{
+				Fqdn:    "bar.svc.svc.cluster.local",
+				Service: Service{Name: "bar", Namespace: "svc"},
+			},
+		}
+		for _, testCase := range passTestCases {
+			s, err := ServiceFromFqdn(testCase.Fqdn)
+			Expect(err).To(Succeed())
+			if err != nil {
+				continue
+			}
+			Expect(s.Name).To(Equal(testCase.Service.Name))
+			Expect(s.Namespace).To(Equal(testCase.Service.Namespace))
+		}
+	})
+	It("should reject invalid FQDNs", func() {
+		failTestCases := []string{
+			"cluster.local",
+			"svc.cluster.local",
+			"default.svc.cluster.local",
+			".default.svc.cluster.local",
+			"..default.svc.cluster.local",
+			"foo.default.svc.cluster.local.",
+		}
+
+		for _, testCase := range failTestCases {
+			_, err := ServiceFromFqdn(testCase)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+})


### PR DESCRIPTION
Problem: there were utility functions related to examining mTLS policies that
were not exported and therefore not easily available for use in other vetters
that needed similar resources, such as the mtlsprobes vetter.

Solution: the functions have been moved into their own directory "mtlspolicy"
within the util directory and exported as needed so that they can be used by
several vetters in the future.

Unit tests were also moved to test the functionality of these utility functions.