### PR TITLE
Documentation updated to point to Istio v0.8 docs

### DIFF
--- a/pkg/vetter/meshversion/README.md
+++ b/pkg/vetter/meshversion/README.md
@@ -1,15 +1,15 @@
 # Mesh Version
 
 The `meshversion` vetter helps detect mismatched, possibly incompatible versions
-of [Istio](https://istio.io/docs/concepts/) components running in the mesh.
+of [Istio](https://archive.istio.io/v0.8/docs/concepts/) components running in the mesh.
 
 Vetter `meshversion` considers the version of Istio
-[Mixer](https://istio.io/docs/concepts/policy-and-control/mixer.html) image
-specified in the `istio-mixer` deployment as the *Istio version* for the cluster.
+[Mixer](https://archive.istio.io/v0.8/docs/concepts/policies-and-telemetry/overview/)
+ image specified in the `istio-mixer` deployment as the *Istio version* for the cluster.
 
 It compares the versions of other installed Istio components like
-[Pilot](https://istio.io/docs/concepts/traffic-management/pilot.html) with the
-*Istio version* and generates notes on version mismatch.
+[Pilot](https://archive.istio.io/v0.8/docs/concepts/traffic-management/pilot/) 
+with the *Istio version* and generates notes on version mismatch.
 
 It also inspects the version of sidecar proxy deployed in pods in the mesh.
 Notes are generated if any version differs from *Istio version*.

--- a/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
+++ b/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
@@ -27,9 +27,10 @@ mesh for this service port.  For instance, if your service port named `backend`
 is using an unknown protocol that runs on top of tcp, rename the service port
 to `tcp-backend`.
 
-In version 0.2.12, these protocols are supported: `grpc`, `https`, `http2`,
+In version 0.8.0, these protocols are supported: `grpc`, `https`, `http2`,
 `http`, `tcp`, `udp`, `mongo`, `redis`.
 
 ## See Also
 
-- [Service Requirements](https://istio.io/docs/setup/kubernetes/spec-requirements/)
+- [Service
+  Requirements](https://archive.istio.io/v0.8/docs/setup/kubernetes/sidecar-injection/#pod-spec-requirements)

--- a/pkg/vetter/serviceportprefix/README.md
+++ b/pkg/vetter/serviceportprefix/README.md
@@ -5,7 +5,7 @@ mesh and generates notes if they are missing Istio recognized port
 protocol prefixes.
 
 Service port names need to be prefixed with the recognized
-[names](https://istio.io/docs/setup/kubernetes/sidecar-injection.html) for Istio
+[names](https://archive.istio.io/v0.8/docs/setup/kubernetes/sidecar-injection/) for Istio
 routing features to work correctly. If a port name doesn't begin with a
 recognized prefix or is unnamed, traffic on the port is treated as plain TCP or
 UDP depending on the port protocol.


### PR DESCRIPTION
Problem: The links in some of the vetter docs were pointing to docs for the
current version of Istio (v1.0) where things may have changed. Since the vetters
are currently for Istio v0.8, the links were pointing to the wrong docs.

Solution: All links pointing to Istio docs have been changed to point at the
archived 0.8 docs.