### PR TITLE
MeshVersion Sidecar Vetter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -777,6 +777,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1",
     "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3",
     "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned",
     "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions",
@@ -794,7 +795,9 @@
     "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/wadey/gocovmerge",
+    "istio.io/api/authentication/v1alpha1",
     "istio.io/api/mesh/v1alpha1",
+    "istio.io/api/networking/v1alpha3",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",

--- a/pkg/vetter/meshversion/README-init-image-mismatch.md
+++ b/pkg/vetter/meshversion/README-init-image-mismatch.md
@@ -3,32 +3,34 @@
 ## Example
 
 The pod `your-app-45574414-qhgq3` in namespace `your-app` is running with
-istio-init image `docker.io/istio/init:0.3.0` but your environment is
-injecting `docker.io/istio/init:0.4.0` for new workloads. Consider
+istio-init image `docker.io/istio/proxy_init:1.0.0` but your environment is
+injecting `docker.io/istio/proxy_init:0.8.0` for new workloads. Consider
 upgrading the istio-init container in the pod.
 
 ## Description
 
-The service mesh functions by injecting an istio-init container into every
-Kubernetes pod.  This init container sets up the pod so that the application
-container will send traffic through the sidecar container.
+The service mesh functions by injecting a sidecar proxy container into every
+Kubernetes pod. Sidecars communicate with each other and with the control plane
+to enable mesh features.
 
-The `istio-inject` configmap specifies which istio-init container image to
-inject into new workloads (like Deployments, DaemonSets, and Jobs) when they
-are configured in your cluster.
+Whenever a new pod is created in a namespace where automatic sidecar injection
+has been enabled, the injector will modify your pod by adding Istio components.
 
-This warning is generated when a pod is detected that is using an
-istio-init container from a different image than what is specified in that
-configmap (for new workloads).  If you recreated the same workload from
-scratch, a different istio-init container image would be injected.
+This warning is generated when a pod is using a `istio-init` init container
+image that is different than what the injector uses. If that pod is deleted, the
+replacement pod would be injected with a sidecar matching the image from the
+`istio-sidecar-injector` configmap. 
 
-This image may be missing features, bugfixes or security patches.  It may not
-be fully compatible with the control plane.
+Mismatched images can be problematic for different reasons such as: 
+- missing features, bugfixes, or security patches
+- not compatible with other sidecars or the control plane
+
 
 ## Suggested Resolution
 
-Upgrade the istio-init image for these workloads to match the version in the
-`istio-inject` configmap, by doing one of the following:
+Re-create this pod so it is injected with a new sidecar matching the version in
+the configmap. 
 
-- re-create these workloads again so they are injected with the new istio-init container
-- editing the workload (for example, the Deployment)
+If the pod is managed by a deployment or stateful set, etc., you can delete the
+pod and the pod will be recreated with the correct version. Before deleteing a
+pod, make sure that deleting it will not affect the state of your workload.

--- a/pkg/vetter/meshversion/README-sidecar-image-mismatch.md
+++ b/pkg/vetter/meshversion/README-sidecar-image-mismatch.md
@@ -3,32 +3,34 @@
 ## Example
 
 The pod `your-app-45574414-qhgq3` in namespace `your-app` is running with
-sidecar proxy image `docker.io/istio/proxy_debug:0.3.0` but your environment is
-injecting `docker.io/istio/proxy_debug:0.4.0` for new workloads. Consider
-upgrading the sidecar proxy in the pod.
+sidecar proxy image `docker.io/istio/proxyv2:1.0.0` but your environment is
+injecting `docker.io/istio/proxyv2:0.8.0` for new workloads. Consider upgrading
+the sidecar proxy in the pod.
 
 ## Description
 
 The service mesh functions by injecting a sidecar proxy container into every
-Kubernetes pod.  This sidecar talks to other sidecars and the control plane to
-provide service mesh to your application running in the pod.
+Kubernetes pod. Sidecars communicate with each other and with the control plane
+to enable mesh features.
 
-The `istio-inject` configmap specifies which sidecar container image to inject
-into new workloads (like Deployments, DaemonSets, and Jobs) when they are
-configured in your cluster.
+Whenever a new pod is created in a namespace where automatic sidecar injection
+has been enabled, the injector will modify your pod by adding Istio components.
 
-This warning is generated when a pod is detected that is using a sidecar
-container from a different image than what is specified in that configmap (for
-new workloads).  If you recreated the same workload from scratch, a different
-sidecar container image would be injected.
+This warning is generated when a pod is using a `istio-proxy` sidecar image that
+is different than what the injector uses. If that pod is deleted, the
+replacement pod would be injected with a sidecar matching the image from the
+`istio-sidecar-injector` configmap. 
 
-This image may be missing features, bugfixes or security patches.  It may not
-be fully compatible with other sidecars or the control plane.
+Mismatched images can be problematic for different reasons such as: 
+- missing features, bugfixes, or security patches
+- not compatible with other sidecars or the control plane
+
 
 ## Suggested Resolution
 
-Upgrade the sidecar image for these workloads to match the version in the
-`istio-inject` configmap, by doing one of the following:
+Re-create this pod so it is injected with a new sidecar matching the version in
+the configmap. 
 
-- re-create these workloads again so they are injected with the new sidecar.
-- editing the workload (for example, the Deployment)
+If the pod is managed by a deployment or stateful set, etc., you can delete the
+pod and the pod will be recreated with the correct version. Before deleteing a
+pod, make sure that deleting it will not affect the state of your workload.

--- a/pkg/vetter/meshversion/README.md
+++ b/pkg/vetter/meshversion/README.md
@@ -1,18 +1,11 @@
 # Mesh Version
 
 The `meshversion` vetter helps detect mismatched, possibly incompatible versions
-of [Istio](https://archive.istio.io/v0.8/docs/concepts/) components running in the mesh.
+of [Istio](https://istio.io/docs/concepts/) components running in the mesh.
 
-Vetter `meshversion` considers the version of Istio
-[Mixer](https://archive.istio.io/v0.8/docs/concepts/policies-and-telemetry/overview/)
- image specified in the `istio-mixer` deployment as the *Istio version* for the cluster.
-
-It compares the versions of other installed Istio components like
-[Pilot](https://archive.istio.io/v0.8/docs/concepts/traffic-management/pilot/) 
-with the *Istio version* and generates notes on version mismatch.
-
-It also inspects the version of sidecar proxy deployed in pods in the mesh.
-Notes are generated if any version differs from *Istio version*.
+When automatic sidecar injection is enabled for pods in the mesh, this vetter
+compares the version of Istio to the version of the Istio containers for each
+pod in the mesh, then generates notes upon version mismatch.
 
 Version mismatch in various components can lead to unexpected behavior or policy
 violations due to incompatibility. It is recommended to upgrade the reported
@@ -22,4 +15,3 @@ components to the *Istio version*.
 
 - [Mismatched sidecar version](README-sidecar-image-mismatch.md)
 - [Mismatched init container version](README-init-image-mismatch.md)
-

--- a/pkg/vetter/meshversion/meshversion_suite_test.go
+++ b/pkg/vetter/meshversion/meshversion_suite_test.go
@@ -1,0 +1,13 @@
+package meshversion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMeshversion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Meshversion Suite")
+}

--- a/pkg/vetter/meshversion/meshversion_test.go
+++ b/pkg/vetter/meshversion/meshversion_test.go
@@ -1,0 +1,124 @@
+package meshversion
+
+import (
+	"fmt"
+	"sort"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func pod(name, namespace, scImage, initImage string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				corev1.Container{
+					Name:  "istio-proxy",
+					Image: scImage,
+				},
+			},
+			InitContainers: []corev1.Container{
+				corev1.Container{
+					Name:  "istio-init",
+					Image: initImage,
+				},
+			},
+		},
+	}
+}
+
+func sortNotes(notes []*apiv1.Note) []*apiv1.Note {
+	sort.Slice(notes, func(i, j int) bool {
+		if notes[i].Attr["namespace"] != notes[j].Attr["namespace"] {
+			return notes[i].Attr["namespace"] < notes[j].Attr["namespace"]
+		}
+		if notes[i].Attr["pod_name"] != notes[j].Attr["pod_name"] {
+			return notes[i].Attr["pod_name"] < notes[j].Attr["pod_name"]
+		}
+		if notes[i].Attr["init_image"] != notes[j].Attr["init_image"] {
+			return notes[i].Attr["init_image"] < notes[j].Attr["init_image"]
+		}
+		if notes[i].Attr["inject_init_image"] != notes[j].Attr["inject_init_image"] {
+			return notes[i].Attr["inject_init_image"] < notes[j].Attr["inject_init_image"]
+		}
+		if notes[i].Attr["sidecar_image"] != notes[j].Attr["sidecar_image"] {
+			return notes[i].Attr["sidecar_image"] < notes[j].Attr["sidecar_image"]
+		}
+		if notes[i].Attr["inject_sidecar_image"] != notes[j].Attr["inject_sidecar_image"] {
+			return notes[i].Attr["inject_sidecar_image"] < notes[j].Attr["inject_sidecar_image"]
+		}
+		return false
+	})
+	return notes
+}
+
+var _ = Describe("Meshversion", func() {
+
+	Describe("Meshversion can write Notes", func() {
+		It("returns the right notes", func() {
+			pods := []*corev1.Pod{}
+			imagedot8 := "docker.io/istio/proxy_init:0.8.0"
+			image1dot0 := "docker.io/istio/proxy_init:1.0.0"
+
+			a := pod("name1", "namespace1", imagedot8, imagedot8)   //make no note
+			b := pod("name2", "namespace1", image1dot0, image1dot0) //make 2 notes
+			c := pod("name3", "namespace1", image1dot0, imagedot8)  //make 1 note re: sidecar
+			d := pod("name4", "namespace1", imagedot8, image1dot0)  //make 1 note re: init
+
+			pods = append(pods, a, b, c, d)
+
+			iImages := injectImages{
+				Init:    imagedot8,
+				Sidecar: imagedot8,
+			}
+
+			notes := vetPods(pods, iImages)
+			sortNotes(notes)
+
+			fmt.Fprintf(GinkgoWriter, "notes[0] %v | %v | %v | %v ", notes[0].Attr["namespace"], notes[0].Attr["pod_name"], notes[0].Attr["sidecar_image"], notes[0].Attr["inject_sidecar_image"])
+			fmt.Fprintf(GinkgoWriter, "notes[1] %v | %v | %v | %v ", notes[1].Attr["namespace"], notes[1].Attr["pod_name"], notes[1].Attr["init_image"], notes[1].Attr["inject_init_image"])
+			fmt.Fprintf(GinkgoWriter, "notes[2] %v | %v | %v | %v ", notes[2].Attr["namespace"], notes[2].Attr["pod_name"], notes[2].Attr["sidecar_image"], notes[2].Attr["inject_sidecar_image"])
+			fmt.Fprintf(GinkgoWriter, "notes[3] %v | %v | %v | %v ", notes[3].Attr["namespace"], notes[3].Attr["pod_name"], notes[3].Attr["init_image"], notes[3].Attr["inject_init_image"])
+
+			Expect(len(notes)).To(Equal(4))
+
+			Expect(notes[0].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[0].Attr["pod_name"]).To(Equal("name2"))
+			Expect(notes[0].Attr["sidecar_image"]).To(Equal("docker.io/istio/proxy_init:1.0.0"))
+			Expect(notes[0].Attr["inject_sidecar_image"]).To(Equal("docker.io/istio/proxy_init:0.8.0"))
+			Expect(notes[0].Attr["inject_init_image"]).To(BeEmpty())
+			Expect(notes[0].Msg).To(Equal(sidecarMismatchMsg))
+
+			Expect(notes[1].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[1].Attr["pod_name"]).To(Equal("name2"))
+			Expect(notes[1].Attr["init_image"]).To(Equal("docker.io/istio/proxy_init:1.0.0"))
+			Expect(notes[1].Attr["inject_init_image"]).To(Equal("docker.io/istio/proxy_init:0.8.0"))
+			Expect(notes[1].Attr["inject_sidecar_image"]).To(BeEmpty())
+			Expect(notes[1].Msg).To(Equal(initMismatchMsg))
+
+			Expect(notes[2].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[2].Attr["pod_name"]).To(Equal("name3"))
+			Expect(notes[2].Attr["sidecar_image"]).To(Equal("docker.io/istio/proxy_init:1.0.0"))
+			Expect(notes[2].Attr["inject_sidecar_image"]).To(Equal("docker.io/istio/proxy_init:0.8.0"))
+			Expect(notes[2].Attr["inject_init_image"]).To(BeEmpty())
+			Expect(notes[2].Msg).To(Equal(sidecarMismatchMsg))
+
+			Expect(notes[3].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[3].Attr["pod_name"]).To(Equal("name4"))
+			Expect(notes[3].Attr["init_image"]).To(Equal("docker.io/istio/proxy_init:1.0.0"))
+			Expect(notes[3].Attr["inject_init_image"]).To(Equal("docker.io/istio/proxy_init:0.8.0"))
+			Expect(notes[3].Attr["inject_sidecar_image"]).To(BeEmpty())
+			Expect(notes[3].Msg).To(Equal(initMismatchMsg))
+
+		})
+	})
+
+})

--- a/pkg/vetter/util/testdata/0.8/0.8-istio-sidecar-injector.yaml
+++ b/pkg/vetter/util/testdata/0.8/0.8-istio-sidecar-injector.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+data:
+  config: "policy: enabled\ntemplate: |-\n  initContainers:\n  - name: istio-init\n
+    \   image: docker.io/istio/proxy_init:0.8.0\n    args:\n    - \"-p\"\n    - [[
+    .MeshConfig.ProxyListenPort ]]\n    - \"-u\"\n    - 1337\n    - \"-m\"\n    -
+    [[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String
+    ]]\n    - \"-i\"\n    [[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\")
+    -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"
+    \ ]]\"\n    [[ else -]]\n    - \"*\"\n    [[ end -]]\n    - \"-x\"\n    [[ if
+    (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundIPRanges\")
+    -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundIPRanges\"
+    \ ]]\"\n    [[ else -]]\n    - \"\"\n    [[ end -]]\n    - \"-b\"\n    [[ if (isset
+    .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeInboundPorts\") -]]\n
+    \   - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeInboundPorts\"
+    \ ]]\"\n    [[ else -]]\n    - [[ range .Spec.Containers -]][[ range .Ports -]][[
+    .ContainerPort -]], [[ end -]][[ end -]][[ end]]\n    - \"-d\"\n    [[ if (isset
+    .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeInboundPorts\") -]]\n
+    \   - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeInboundPorts\"
+    ]]\"\n    [[ else -]]\n    - \"\"\n    [[ end -]]\n    imagePullPolicy: IfNotPresent\n
+    \   securityContext:\n      capabilities:\n        add:\n        - NET_ADMIN\n
+    \     privileged: true\n    restartPolicy: Always\n  \n  containers:\n  - name:
+    istio-proxy\n    image: [[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\")
+    -]]\n    \"[[ index .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\" ]]\"\n
+    \   [[ else -]]\n    docker.io/istio/proxyv2:0.8.0\n    [[ end -]]\n    args:\n
+    \   - proxy\n    - sidecar\n    - --configPath\n    - [[ .ProxyConfig.ConfigPath
+    ]]\n    - --binaryPath\n    - [[ .ProxyConfig.BinaryPath ]]\n    - --serviceCluster\n
+    \   [[ if ne \"\" (index .ObjectMeta.Labels \"app\") -]]\n    - [[ index .ObjectMeta.Labels
+    \"app\" ]]\n    [[ else -]]\n    - \"istio-proxy\"\n    [[ end -]]\n    - --drainDuration\n
+    \   - [[ formatDuration .ProxyConfig.DrainDuration ]]\n    - --parentShutdownDuration\n
+    \   - [[ formatDuration .ProxyConfig.ParentShutdownDuration ]]\n    - --discoveryAddress\n
+    \   - [[ .ProxyConfig.DiscoveryAddress ]]\n    - --discoveryRefreshDelay\n    -
+    [[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]\n    - --zipkinAddress\n
+    \   - [[ .ProxyConfig.ZipkinAddress ]]\n    - --connectTimeout\n    - [[ formatDuration
+    .ProxyConfig.ConnectTimeout ]]\n    - --statsdUdpAddress\n    - [[ .ProxyConfig.StatsdUdpAddress
+    ]]\n    - --proxyAdminPort\n    - [[ .ProxyConfig.ProxyAdminPort ]]\n    - --controlPlaneAuthPolicy\n
+    \   - [[ .ProxyConfig.ControlPlaneAuthPolicy ]]\n    env:\n    - name: POD_NAME\n
+    \     valueFrom:\n        fieldRef:\n          fieldPath: metadata.name\n    -
+    name: POD_NAMESPACE\n      valueFrom:\n        fieldRef:\n          fieldPath:
+    metadata.namespace\n    - name: INSTANCE_IP\n      valueFrom:\n        fieldRef:\n
+    \         fieldPath: status.podIP\n    - name: ISTIO_META_POD_NAME\n      valueFrom:\n
+    \       fieldRef:\n          fieldPath: metadata.name\n    - name: ISTIO_META_INTERCEPTION_MODE\n
+    \     value: [[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\")
+    .ProxyConfig.InterceptionMode.String ]]\n    imagePullPolicy: IfNotPresent\n    securityContext:\n
+    \       privileged: false\n        readOnlyRootFilesystem: true\n        [[ if
+    eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String)
+    \"TPROXY\" -]]\n        capabilities:\n          add:\n          - NET_ADMIN\n
+    \       [[ else -]]\n        runAsUser: 1337\n        [[ end -]]\n    restartPolicy:
+    Always\n    resources:\n      requests:\n        cpu: 100m\n        memory: 128Mi\n
+    \     \n    volumeMounts:\n    - mountPath: /etc/istio/proxy\n      name: istio-envoy\n
+    \   - mountPath: /etc/certs/\n      name: istio-certs\n      readOnly: true\n
+    \ volumes:\n  - emptyDir:\n      medium: Memory\n    name: istio-envoy\n  - name:
+    istio-certs\n    secret:\n      optional: true\n      [[ if eq .Spec.ServiceAccountName
+    \"\" -]]\n      secretName: istio.default\n      [[ else -]]\n      secretName:
+    [[ printf \"istio.%s\" .Spec.ServiceAccountName ]]\n      [[ end -]]"
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"config":"policy: enabled\ntemplate: |-\n  initContainers:\n  - name: istio-init\n    image: docker.io/istio/proxy_init:0.8.0\n    args:\n    - \"-p\"\n    - [[ .MeshConfig.ProxyListenPort ]]\n    - \"-u\"\n    - 1337\n    - \"-m\"\n    - [[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]\n    - \"-i\"\n    [[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\") -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"  ]]\"\n    [[ else -]]\n    - \"*\"\n    [[ end -]]\n    - \"-x\"\n    [[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundIPRanges\") -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundIPRanges\"  ]]\"\n    [[ else -]]\n    - \"\"\n    [[ end -]]\n    - \"-b\"\n    [[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeInboundPorts\") -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeInboundPorts\"  ]]\"\n    [[ else -]]\n    - [[ range .Spec.Containers -]][[ range .Ports -]][[ .ContainerPort -]], [[ end -]][[ end -]][[ end]]\n    - \"-d\"\n    [[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeInboundPorts\") -]]\n    - \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeInboundPorts\" ]]\"\n    [[ else -]]\n    - \"\"\n    [[ end -]]\n    imagePullPolicy: IfNotPresent\n    securityContext:\n      capabilities:\n        add:\n        - NET_ADMIN\n      privileged: true\n    restartPolicy: Always\n  \n  containers:\n  - name: istio-proxy\n    image: [[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\") -]]\n    \"[[ index .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\" ]]\"\n    [[ else -]]\n    docker.io/istio/proxyv2:0.8.0\n    [[ end -]]\n    args:\n    - proxy\n    - sidecar\n    - --configPath\n    - [[ .ProxyConfig.ConfigPath ]]\n    - --binaryPath\n    - [[ .ProxyConfig.BinaryPath ]]\n    - --serviceCluster\n    [[ if ne \"\" (index .ObjectMeta.Labels \"app\") -]]\n    - [[ index .ObjectMeta.Labels \"app\" ]]\n    [[ else -]]\n    - \"istio-proxy\"\n    [[ end -]]\n    - --drainDuration\n    - [[ formatDuration .ProxyConfig.DrainDuration ]]\n    - --parentShutdownDuration\n    - [[ formatDuration .ProxyConfig.ParentShutdownDuration ]]\n    - --discoveryAddress\n    - [[ .ProxyConfig.DiscoveryAddress ]]\n    - --discoveryRefreshDelay\n    - [[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]\n    - --zipkinAddress\n    - [[ .ProxyConfig.ZipkinAddress ]]\n    - --connectTimeout\n    - [[ formatDuration .ProxyConfig.ConnectTimeout ]]\n    - --statsdUdpAddress\n    - [[ .ProxyConfig.StatsdUdpAddress ]]\n    - --proxyAdminPort\n    - [[ .ProxyConfig.ProxyAdminPort ]]\n    - --controlPlaneAuthPolicy\n    - [[ .ProxyConfig.ControlPlaneAuthPolicy ]]\n    env:\n    - name: POD_NAME\n      valueFrom:\n        fieldRef:\n          fieldPath: metadata.name\n    - name: POD_NAMESPACE\n      valueFrom:\n        fieldRef:\n          fieldPath: metadata.namespace\n    - name: INSTANCE_IP\n      valueFrom:\n        fieldRef:\n          fieldPath: status.podIP\n    - name: ISTIO_META_POD_NAME\n      valueFrom:\n        fieldRef:\n          fieldPath: metadata.name\n    - name: ISTIO_META_INTERCEPTION_MODE\n      value: [[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]\n    imagePullPolicy: IfNotPresent\n    securityContext:\n        privileged: false\n        readOnlyRootFilesystem: true\n        [[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]\n        capabilities:\n          add:\n          - NET_ADMIN\n        [[ else -]]\n        runAsUser: 1337\n        [[ end -]]\n    restartPolicy: Always\n    resources:\n      requests:\n        cpu: 100m\n        memory: 128Mi\n      \n    volumeMounts:\n    - mountPath: /etc/istio/proxy\n      name: istio-envoy\n    - mountPath: /etc/certs/\n      name: istio-certs\n      readOnly: true\n  volumes:\n  - emptyDir:\n      medium: Memory\n    name: istio-envoy\n  - name: istio-certs\n    secret:\n      optional: true\n      [[ if eq .Spec.ServiceAccountName \"\" -]]\n      secretName: istio.default\n      [[ else -]]\n      secretName: [[ printf \"istio.%s\" .Spec.ServiceAccountName ]]\n      [[ end -]]"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"istio","chart":"istio-0.8.0","heritage":"Tiller","istio":"sidecar-injector","release":"RELEASE-NAME"},"name":"istio-sidecar-injector","namespace":"istio-system"}}
+  creationTimestamp: null
+  labels:
+    app: istio
+    chart: istio-0.8.0
+    heritage: Tiller
+    istio: sidecar-injector
+    release: RELEASE-NAME
+  name: istio-sidecar-injector
+  selfLink: /api/v1/namespaces/istio-system/configmaps/istio-sidecar-injector

--- a/pkg/vetter/util/testdata/0.8/0.8-mesh-config.yaml
+++ b/pkg/vetter/util/testdata/0.8/0.8-mesh-config.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+data:
+  mesh: |-
+    #
+    # Edit this list to avoid using mTLS to connect to these services.
+    # Typically, these are control services (e.g kubernetes API server) that don't have istio sidecar
+    # to transparently terminate mTLS authentication.
+    # mtlsExcludedServices: ["kubernetes.default.svc.cluster.local"]
+
+    # Set the following variable to true to disable policy checks by the Mixer.
+    # Note that metrics will still be reported to the Mixer.
+    disablePolicyChecks: false
+    # Set enableTracing to false to disable request tracing.
+    enableTracing: true
+    #
+    # To disable the mixer completely (including metrics), comment out
+    # the following lines
+    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004
+    mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:15004
+    # This is the ingress service name, update if you used a different name
+    ingressService: istio-ingress
+    #
+    # Along with discoveryRefreshDelay, this setting determines how
+    # frequently should Envoy fetch and update its internal configuration
+    # from istio Pilot. Lower refresh delay results in higher CPU
+    # utilization and potential performance loss in exchange for faster
+    # convergence. Tweak this value according to your setup.
+    rdsRefreshDelay: 10s
+    #
+    defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress pods.
+      # See rdsRefreshDelay for explanation about this setting.
+      discoveryRefreshDelay: 10s
+      #
+      # TCP connection timeout between Envoy & the application, and between Envoys.
+      connectTimeout: 10s
+      #
+      ### ADVANCED SETTINGS #############
+      # Where should envoy's configuration be stored in the istio-proxy container
+      configPath: "/etc/istio/proxy"
+      binaryPath: "/usr/local/bin/envoy"
+      # The pseudo service name used for Envoy.
+      serviceCluster: istio-proxy
+      # These settings that determine how long an old Envoy
+      # process should be kept alive after an occasional reload.
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      #
+      # The mode used to redirect inbound connections to Envoy. This setting
+      # has no effect on outbound traffic: iptables REDIRECT is always used for
+      # outbound connections.
+      # If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+      # The "REDIRECT" mode loses source addresses during redirection.
+      # If "TPROXY", use iptables TPROXY to redirect to Envoy.
+      # The "TPROXY" mode preserves both the source and destination IP
+      # addresses and ports, so that they can be used for advanced filtering
+      # and manipulation.
+      # The "TPROXY" mode also configures the sidecar to run with the
+      # CAP_NET_ADMIN capability, which is required to use TPROXY.
+      #interceptionMode: REDIRECT
+      #
+      # Port where Envoy listens (on local host) for admin commands
+      # You can exec into the istio-proxy container in a pod and
+      # curl the admin port (curl http://localhost:15000/) to obtain
+      # diagnostic information from Envoy. See
+      # https://lyft.github.io/envoy/docs/operations/admin.html
+      # for more details
+      proxyAdminPort: 15000
+      #
+      # Zipkin trace collector
+      zipkinAddress: zipkin.istio-system:9411
+      #
+      # Statsd metrics collector converts statsd metrics into Prometheus metrics.
+      statsdUdpAddress: istio-statsd-prom-bridge.istio-system:9125
+      #
+      # Mutual TLS authentication between sidecars and istio control plane.
+      controlPlaneAuthPolicy: NONE
+      #
+      # Address where istio Pilot service is running
+      discoveryAddress: istio-pilot.istio-system:15007
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"mesh":"#\n# Edit this list to avoid using mTLS to connect to these services.\n# Typically, these are control services (e.g kubernetes API server) that don't have istio sidecar\n# to transparently terminate mTLS authentication.\n# mtlsExcludedServices: [\"kubernetes.default.svc.cluster.local\"]\n\n# Set the following variable to true to disable policy checks by the Mixer.\n# Note that metrics will still be reported to the Mixer.\ndisablePolicyChecks: false\n# Set enableTracing to false to disable request tracing.\nenableTracing: true\n#\n# To disable the mixer completely (including metrics), comment out\n# the following lines\nmixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004\nmixerReportServer: istio-telemetry.istio-system.svc.cluster.local:15004\n# This is the ingress service name, update if you used a different name\ningressService: istio-ingress\n#\n# Along with discoveryRefreshDelay, this setting determines how\n# frequently should Envoy fetch and update its internal configuration\n# from istio Pilot. Lower refresh delay results in higher CPU\n# utilization and potential performance loss in exchange for faster\n# convergence. Tweak this value according to your setup.\nrdsRefreshDelay: 10s\n#\ndefaultConfig:\n  # NOTE: If you change any values in this section, make sure to make\n  # the same changes in start up args in istio-ingress pods.\n  # See rdsRefreshDelay for explanation about this setting.\n  discoveryRefreshDelay: 10s\n  #\n  # TCP connection timeout between Envoy \u0026 the application, and between Envoys.\n  connectTimeout: 10s\n  #\n  ### ADVANCED SETTINGS #############\n  # Where should envoy's configuration be stored in the istio-proxy container\n  configPath: \"/etc/istio/proxy\"\n  binaryPath: \"/usr/local/bin/envoy\"\n  # The pseudo service name used for Envoy.\n  serviceCluster: istio-proxy\n  # These settings that determine how long an old Envoy\n  # process should be kept alive after an occasional reload.\n  drainDuration: 45s\n  parentShutdownDuration: 1m0s\n  #\n  # The mode used to redirect inbound connections to Envoy. This setting\n  # has no effect on outbound traffic: iptables REDIRECT is always used for\n  # outbound connections.\n  # If \"REDIRECT\", use iptables REDIRECT to NAT and redirect to Envoy.\n  # The \"REDIRECT\" mode loses source addresses during redirection.\n  # If \"TPROXY\", use iptables TPROXY to redirect to Envoy.\n  # The \"TPROXY\" mode preserves both the source and destination IP\n  # addresses and ports, so that they can be used for advanced filtering\n  # and manipulation.\n  # The \"TPROXY\" mode also configures the sidecar to run with the\n  # CAP_NET_ADMIN capability, which is required to use TPROXY.\n  #interceptionMode: REDIRECT\n  #\n  # Port where Envoy listens (on local host) for admin commands\n  # You can exec into the istio-proxy container in a pod and\n  # curl the admin port (curl http://localhost:15000/) to obtain\n  # diagnostic information from Envoy. See\n  # https://lyft.github.io/envoy/docs/operations/admin.html\n  # for more details\n  proxyAdminPort: 15000\n  #\n  # Zipkin trace collector\n  zipkinAddress: zipkin.istio-system:9411\n  #\n  # Statsd metrics collector converts statsd metrics into Prometheus metrics.\n  statsdUdpAddress: istio-statsd-prom-bridge.istio-system:9125\n  #\n  # Mutual TLS authentication between sidecars and istio control plane.\n  controlPlaneAuthPolicy: NONE\n  #\n  # Address where istio Pilot service is running\n  discoveryAddress: istio-pilot.istio-system:15007"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"istio","chart":"istio-0.8.0","heritage":"Tiller","release":"RELEASE-NAME"},"name":"istio","namespace":"istio-system"}}
+  creationTimestamp: null
+  labels:
+    app: istio
+    chart: istio-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: istio
+  selfLink: /api/v1/namespaces/istio-system/configmaps/istio


### PR DESCRIPTION
Problem: Istio made changes that affected existing code and disabled the meshversion vetter.

Solution: Changes were made to the vetter/utils functions that create a sidecar injector spec to match Istio 0.8.0. Both vetter/utils and vetter/meshversion/vet.go were refactored to enable better testing. READMEs have been updated.