### PR TITLE
Update vet docs for 1.0

### DIFF
--- a/pkg/vetter/applabel/README.md
+++ b/pkg/vetter/applabel/README.md
@@ -4,7 +4,7 @@ The `applabel` vetter inspects the labels defined for the pods in the mesh and
 generates notes if the label `app` is missing on any pod.
 
 The label `app` is used to add contextual information in tracing information
-collected by the mesh. It is recommended to add uniqiue and meaningful `app`
+collected by the mesh. It is recommended to add unique and meaningful `app`
 label to the pods in the mesh in order to collect useful tracing data.
 
 ## Notes Generated

--- a/pkg/vetter/meshversion/README-init-image-mismatch.md
+++ b/pkg/vetter/meshversion/README-init-image-mismatch.md
@@ -3,8 +3,8 @@
 ## Example
 
 The pod `your-app-45574414-qhgq3` in namespace `your-app` is running with
-istio-init image `docker.io/istio/proxy_init:1.0.0` but your environment is
-injecting `docker.io/istio/proxy_init:0.8.0` for new workloads. Consider
+istio-init image `docker.io/istio/proxy_init:0.8.0` but your environment is
+injecting `docker.io/istio/proxy_init:1.0.0` for new workloads. Consider
 upgrading the istio-init container in the pod.
 
 ## Description
@@ -32,5 +32,5 @@ Re-create this pod so it is injected with a new sidecar matching the version in
 the configmap. 
 
 If the pod is managed by a deployment or stateful set, etc., you can delete the
-pod and the pod will be recreated with the correct version. Before deleteing a
+pod and the pod will be recreated with the correct version. Before deleting a
 pod, make sure that deleting it will not affect the state of your workload.

--- a/pkg/vetter/meshversion/README-sidecar-image-mismatch.md
+++ b/pkg/vetter/meshversion/README-sidecar-image-mismatch.md
@@ -3,8 +3,8 @@
 ## Example
 
 The pod `your-app-45574414-qhgq3` in namespace `your-app` is running with
-sidecar proxy image `docker.io/istio/proxyv2:1.0.0` but your environment is
-injecting `docker.io/istio/proxyv2:0.8.0` for new workloads. Consider upgrading
+sidecar proxy image `docker.io/istio/proxyv2:0.8.0` but your environment is
+injecting `docker.io/istio/proxyv2:1.0.0` for new workloads. Consider upgrading
 the sidecar proxy in the pod.
 
 ## Description
@@ -32,5 +32,5 @@ Re-create this pod so it is injected with a new sidecar matching the version in
 the configmap. 
 
 If the pod is managed by a deployment or stateful set, etc., you can delete the
-pod and the pod will be recreated with the correct version. Before deleteing a
+pod and the pod will be recreated with the correct version. Before deleting a
 pod, make sure that deleting it will not affect the state of your workload.

--- a/pkg/vetter/mtlsprobes/README-mtls-probes-incompatible.md
+++ b/pkg/vetter/mtlsprobes/README-mtls-probes-incompatible.md
@@ -201,7 +201,7 @@ this technique, make sure your pod will exit if it becomes unhealthy.
 
 ## See also
 
-- [Istio mTLS](https://archive.istio.io/v0.8/docs/concepts/security/mutual-tls/)
+- [Istio mTLS](https://istio.io/docs/concepts/security/mutual-tls/)
 - [Liveness Commands](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-command)
 - [istio/old_auth_repo#262](https://github.com/istio/old_auth_repo/issues/262)
 - [istio/old_auth_repo#292](https://github.com/istio/old_auth_repo/issues/292)

--- a/pkg/vetter/mtlsprobes/README.md
+++ b/pkg/vetter/mtlsprobes/README.md
@@ -1,7 +1,7 @@
 # mTLS Probes
 
 The `mtlsprobes` vetter verifies if
-[mTLS](https://archive.istio.io/v0.8/docs/tasks/security/mutual-tls/)
+[mTLS](https://istio.io/docs/tasks/security/mutual-tls/)
 is enabled in the Istio service mesh along with HTTP or TCP
 [probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 (Liveness or Readiness) in any of the Pods in the mesh.

--- a/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
+++ b/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
@@ -27,10 +27,9 @@ mesh for this service port.  For instance, if your service port named `backend`
 is using an unknown protocol that runs on top of tcp, rename the service port
 to `tcp-backend`.
 
-In version 0.8.0, these protocols are supported: `grpc`, `https`, `http2`,
+In version 1.0.0, these protocols are supported: `grpc`, `https`, `http2`,
 `http`, `tcp`, `udp`, `mongo`, `redis`.
 
 ## See Also
 
-- [Service
-  Requirements](https://archive.istio.io/v0.8/docs/setup/kubernetes/sidecar-injection/#pod-spec-requirements)
+- [Pod and Service Requirements](https://istio.io/docs/setup/kubernetes/spec-requirements/)

--- a/pkg/vetter/serviceportprefix/README.md
+++ b/pkg/vetter/serviceportprefix/README.md
@@ -5,7 +5,7 @@ mesh and generates notes if they are missing Istio recognized port
 protocol prefixes.
 
 Service port names need to be prefixed with the recognized
-[names](https://archive.istio.io/v0.8/docs/setup/kubernetes/sidecar-injection/) for Istio
+[names](https://istio.io/docs/setup/kubernetes/sidecar-injection/) for Istio
 routing features to work correctly. If a port name doesn't begin with a
 recognized prefix or is unnamed, traffic on the port is treated as plain TCP or
 UDP depending on the port protocol.


### PR DESCRIPTION
Problem:
The docs were last updated for version 0.8, but the current release is 1.0

Solution:
Update the docs to refer to the current version. Also fixed a spelling error or
two