### PR TITLE
Util functions check global mTLS status for v1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c5387e857e59d19a8c065b93a97c77b8b7cd3f4fd8fdd797318832960023b8ec"
+  digest = "1:524ca331d8c6995ff9e300f390ed7e60809f649c359fa083278ab8c6750dbc3c"
   name = "github.com/aspenmesh/istio-client-go"
   packages = [
     "pkg/apis/authentication",
@@ -40,7 +40,7 @@
     "pkg/client/listers/networking/v1alpha3",
   ]
   pruneopts = ""
-  revision = "a681158dee6f9b87eac817150043d347fa4d5a6e"
+  revision = "0b9cde3479b22ad5530b008c119b3914e634ba6c"
 
 [[projects]]
   branch = "master"
@@ -121,7 +121,9 @@
   digest = "1:70a80170917a15e1ff02faab5f9e716e945e0676e86599ba144d38f96e30c3bf"
   name = "github.com/gogo/protobuf"
   packages = [
+    "gogoproto",
     "proto",
+    "protoc-gen-gogo/descriptor",
     "sortkeys",
     "types",
   ]
@@ -548,8 +550,8 @@
   revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [[projects]]
-  branch = "release-0.8"
-  digest = "1:383cf412f31ab1f782b56ab0ecfca27548bf7aaf171f4ec85c7d1ac7e97bf540"
+  branch = "release-1.0"
+  digest = "1:bc43af6616d8ca12a7b8e806874387f0f1e181c08f547e9cd77f6cbac8cefd86"
   name = "istio.io/api"
   packages = [
     "authentication/v1alpha1",
@@ -557,7 +559,7 @@
     "networking/v1alpha3",
   ]
   pruneopts = ""
-  revision = "8d67e57e3612dae1a3423795bce93a372cfe4fa4"
+  revision = "76349c53b87f03f1e610b3aa3843dba3c38138d7"
 
 [[projects]]
   digest = "1:f9fa227c63f7ed1bbc0efdee23a87c90e09e01d604608f3d662a1691142bac2d"
@@ -781,6 +783,7 @@
     "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3",
     "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned",
     "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions",
+    "github.com/aspenmesh/istio-client-go/pkg/client/listers/authentication/v1alpha1",
     "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3",
     "github.com/cnf/structhash",
     "github.com/ghodss/yaml",
@@ -801,6 +804,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/listers/core/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,7 +55,7 @@ required = [
 
 [[constraint]]
   name = "istio.io/api"
-  branch = "release-0.8"
+  branch = "release-1.0"
 
 [[constraint]]
   name = "k8s.io/api"

--- a/pkg/vetter/mtlsprobes/README-mtls-probes-incompatible.md
+++ b/pkg/vetter/mtlsprobes/README-mtls-probes-incompatible.md
@@ -26,8 +26,9 @@ a CrashLoopBackOff state.
 ## Auth Policies Enabling/Disabling mTLS
 
 Authorization policies can enable or disable mTLS at the port, service name, and
-service namespace level. This will override the global mTLS setting for the
-port/name/namespace specified.
+service namespace level. This will override the [global mTLS
+setting](https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls) 
+for the port/name/namespace specified.
 
 ### Sample Configurations and Auth Policies
 
@@ -141,8 +142,9 @@ fix this by defining an authentication policy for your service.
 
 You can do one of these things:
 
-- **Define an Authentication Policy for your Service.** As of Istio v0.8 you can
-  define an authentication policy that disables mTLS for the port of the 
+- **Disable mTLS for the health probe port.**  To do this, you will need to
+  define an Authentication Policy for your Service.  In Istio v1.0 you can
+define an Authentication Policy that disables mTLS for the port of the 
 liveness/readiness probe.  It is recommended to use a port that is specific for
 health probes, and to disable mTLS on that port.  If the application port is
 also used for the health port and mTLS is disabled on this shared port, mTLS
@@ -185,10 +187,6 @@ mTLS.
       initialDelaySeconds: 10
       periodSeconds: 5
     ```
-
-- **Disable mTLS.**  Pod-to-pod traffic is still encrypted on the wire but it
-  is possible that a rogue, non-mesh pod could impersonate another mesh pod
-when doing pod-to-pod communication.
 
 - **Disable liveness probes.** You can remove liveness and readiness probes
   from your pod spec.  In this case, the kubelet will not be able to determine

--- a/pkg/vetter/util/mtlspolicy/destinationRule.go
+++ b/pkg/vetter/util/mtlspolicy/destinationRule.go
@@ -38,7 +38,7 @@ type destRulesByNamespaceNamePortMap map[string]destRulesByNamePortMap
 
 // DestRules holds maps of Istio destination rules by port, name, and namespace
 type DestRules struct {
-	// Destination rules must have a host specifier.  In Istio 0.8 they cannot be
+	// Destination rules must have a host specifier.  In Istio 1.0 they cannot be
 	// cluster-wide, but they can be namespace wide
 	// (*.namespace.svc.cluster.local)
 	namespace destRulesByNamespaceMap
@@ -228,8 +228,8 @@ func LoadDestRules(rules []*netv1alpha3.DestinationRule) (*DestRules, error) {
 		if r.Spec.GetTrafficPolicy().GetTls() != nil {
 			if s.Name == "*" {
 				if s.Namespace == "*" {
-					// This isn't allowed in Istio 0.8
-					// TODO(andrew): Check that it doesn't work in 0.8.
+					// This isn't allowed in Istio 1.0
+					// TODO(andrew): Check that it doesn't work in 1.0.
 					continue
 				}
 				loaded.AddByNamespace(s.Namespace, r)

--- a/pkg/vetter/util/mtlspolicy/meshPolicy.go
+++ b/pkg/vetter/util/mtlspolicy/meshPolicy.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"errors"
+	"strings"
+
+	authv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	istioauthv1alpha1 "istio.io/api/authentication/v1alpha1"
+)
+
+// IsGlobalMtlsEnabled validates that there are the expected number of
+// MeshPolicies in the list (0 or 1), validates the name of the MeshPolicy, and
+// returns true if the MeshPolicy enables mTLS
+func IsGlobalMtlsEnabled(meshPolicies []*authv1alpha1.MeshPolicy) (bool, error) {
+	if len(meshPolicies) > 1 {
+		return false, errors.New("More than one MeshPolicy was found")
+	} else if len(meshPolicies) == 0 {
+		return false, nil
+	} else {
+		if strings.EqualFold(meshPolicies[0].ObjectMeta.Name, "default") {
+			return MeshPolicyIsMtls(meshPolicies[0]), nil
+		} else {
+			return false, errors.New("MeshPolicy is not named 'default'")
+		}
+	}
+}
+
+// MeshPolicyIsMtls returns true if the passed MeshPolicy has mTLS enabled
+func MeshPolicyIsMtls(meshPolicy *authv1alpha1.MeshPolicy) bool {
+	peers := meshPolicy.Spec.GetPeers()
+	if peers == nil {
+		return false
+	}
+	for _, peer := range peers {
+		// mTLS is "on" if there is an mTLS peer entry, even if it is nil.
+		// so e.g.:
+		//   peers:
+		//   - mtls: null
+		// We can't use .GetMtls(), we need to attempt the cast ourselves, because
+		// .GetMtls() will return nil if the peer isn't mTLS AND if the peer is an
+		// empty mTLS, and we won't be able to distinguish.
+		_, ok := peer.GetParams().(*istioauthv1alpha1.PeerAuthenticationMethod_Mtls)
+		if ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/vetter/util/mtlspolicy/meshPolicy_test.go
+++ b/pkg/vetter/util/mtlspolicy/meshPolicy_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtlspolicyutil
+
+import (
+	"errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	authv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	istioauthv1alpha1 "istio.io/api/authentication/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type expectedValue struct {
+	input       []*authv1alpha1.MeshPolicy
+	mtlsEnabled bool
+	err         error
+}
+
+var (
+	defaultOn = &authv1alpha1.MeshPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MeshPolicy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: authv1alpha1.MeshPolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+
+	defaultOff = &authv1alpha1.MeshPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MeshPolicy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: authv1alpha1.MeshPolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{},
+			},
+		},
+	}
+
+	nonDefaultNamedOn = &authv1alpha1.MeshPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MeshPolicy",
+			APIVersion: "authentication.istio.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "named",
+		},
+		Spec: authv1alpha1.MeshPolicySpec{
+			Policy: istioauthv1alpha1.Policy{
+				Peers: []*istioauthv1alpha1.PeerAuthenticationMethod{
+					&istioauthv1alpha1.PeerAuthenticationMethod{
+						Params: &istioauthv1alpha1.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+		},
+	}
+)
+
+var _ = Describe("Test the status of mTLS from MeshPolicies", func() {
+	var expectedValues = []expectedValue{
+		expectedValue{
+			input:       []*authv1alpha1.MeshPolicy{},
+			mtlsEnabled: false,
+			err:         nil,
+		},
+		expectedValue{
+			input:       []*authv1alpha1.MeshPolicy{defaultOn, defaultOff},
+			mtlsEnabled: false,
+			err:         errors.New(""),
+		},
+		expectedValue{
+			input:       []*authv1alpha1.MeshPolicy{defaultOn},
+			mtlsEnabled: true,
+			err:         nil,
+		},
+		expectedValue{
+			input:       []*authv1alpha1.MeshPolicy{defaultOff},
+			mtlsEnabled: false,
+			err:         nil,
+		},
+		expectedValue{
+			input:       []*authv1alpha1.MeshPolicy{nonDefaultNamedOn},
+			mtlsEnabled: false,
+			err:         errors.New(""),
+		},
+	}
+	It("Should match the expected values", func() {
+		for i := 0; i < len(expectedValues); i++ {
+			mtlsEnabled, err := IsGlobalMtlsEnabled(expectedValues[i].input)
+			if expectedValues[i].err != nil {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(mtlsEnabled).To(Equal(expectedValues[i].mtlsEnabled))
+		}
+	})
+
+})


### PR DESCRIPTION
Problem: In Istio v1.0, a new resource (MeshPolicy) is used to enable/disable
global mTLS instead of the Istio Config. Currently only one vetter checks for
the status of global mTLS (the mtlsprobes vetter), but there may be more that
rely on it in the future. We are currently not handling the new MeshPolicy
resource, and we need to do that to comply with the changes in Istio v1.0.

Solution: Utility functions have been added to mtlsutils to take in MeshPolicies
and determine if global mTLS is enabled or disabled. These functions will be
used in the mtlsprobes vetter to update it to work with Istio v1.0.