### PR TITLE
Add GetClusterPortPolicies() to authPolicy.go

### DIFF
--- a/pkg/vetter/util/mtlspolicy/authPolicy.go
+++ b/pkg/vetter/util/mtlspolicy/authPolicy.go
@@ -122,6 +122,19 @@ func (ap *AuthPolicies) ByPort(s Service, port uint32) []*authv1alpha1.Policy {
 	return p
 }
 
+// This returns all the policies for a cluster that whose target is a port, regardless of service or namespace
+func (ap *AuthPolicies) GetClusterPortPolicies() []*authv1alpha1.Policy {
+	portPolicies := []*authv1alpha1.Policy{}
+	for _, polsByNamePortMap := range ap.port {
+		for _, polsByPortMap := range polsByNamePortMap {
+			for _, policies := range polsByPortMap {
+				portPolicies = append(portPolicies, policies...)
+			}
+		}
+	}
+	return portPolicies
+}
+
 // AuthPolicyIsMtls returns true if the passed Policy has mTLS enabled
 func AuthPolicyIsMtls(policy *authv1alpha1.Policy) bool {
 	peers := policy.Spec.GetPeers()

--- a/pkg/vetter/util/mtlspolicy/authPolicy_test.go
+++ b/pkg/vetter/util/mtlspolicy/authPolicy_test.go
@@ -156,6 +156,7 @@ var (
 		},
 	}
 )
+
 var _ = Describe("LoadAuthPolicies", func() {
 	It("should load policies", func() {
 		loaded, err := LoadAuthPolicies([]*authv1alpha1.Policy{
@@ -186,6 +187,21 @@ var _ = Describe("LoadAuthPolicies", func() {
 		Expect(loaded.ByPort(foo, 8443)).To(Equal([]*authv1alpha1.Policy{apFooPortsBarOn}))
 		Expect(loaded.ByPort(foo, 1000)).To(Equal([]*authv1alpha1.Policy{}))
 		Expect(loaded.ByPort(bar, 8443)).To(Equal([]*authv1alpha1.Policy{}))
+	})
+})
+
+var _ = Describe("GetClusterPortPolicies", func() {
+	It("should return port policies from the loaded AuthPolicies struct", func() {
+		loaded, err := LoadAuthPolicies([]*authv1alpha1.Policy{
+			apDefaultOn,
+			apFooOn,
+			apFooOff,
+			apFooBarOn,
+			apFooPortsBarOn,
+		})
+		Expect(err).To(Succeed())
+		portPolicies := loaded.GetClusterPortPolicies()
+		Expect(len(portPolicies)).To(Equal(1))
 	})
 })
 


### PR DESCRIPTION
Problem:  AuthPolicies Struct created by LoadAuthPolicies() has unexported fields, so users cannot access these except by using getters. The Details API MTls Config code needed to access all policies with ports without knowing what the port numbers are in advance, so the port getter was not useful.

Solution: Added one function that returns the whole map of policies that specify a port, and did not change the unexported setup of the AuthPolicies struct.