### PR TITLE
Added a contributing section with CLA to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ It includes:
 
 More details about vetters can be found in the individual vetters package
 documentation.
+
+## Contributing
+Individuals or business entities who contribute to this project must have
+completed and submitted the [F5® Contributor License Agreement](https://github.com/aspenmesh/cla/raw/master/f5-cla.pdf)
+to [cla@aspenmesh.io](mailto:cla@aspenmesh.io) prior to their code submission
+being included in this project. Please include your github username in the CLA email.


### PR DESCRIPTION
As required by F5 policy we need a CLA in place for contributions to be accepted into this project. I added a contributing section to the README with a link to the CLA and the instructions on where to send the completed form.