### PR TITLE
Add Vet for Conflicting Auth Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ It includes:
     This vetter generates warnings if the same host is defined in multiple
     virtual service resources.
 
+  * [authpolicy](https://github.com/aspenmesh/istio-vet/blob/master/pkg/vetter/authpolicy/README.md) -
+    This vetter generates warnings if there are more than one authentication policy for the same target.
+
 More details about vetters can be found in the individual vetters package
 documentation.
 

--- a/pkg/vet/cmd/vet.go
+++ b/pkg/vet/cmd/vet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aspenmesh/istio-vet/pkg/meshclient"
 	"github.com/aspenmesh/istio-vet/pkg/vetter"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/applabel"
+	"github.com/aspenmesh/istio-vet/pkg/vetter/authpolicy"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/conflictingvirtualservicehost"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/danglingroutedestinationhost"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/meshversion"
@@ -93,6 +94,7 @@ func vet(cmd *cobra.Command, args []string) error {
 		vetter.Vetter(serviceassociation.NewVetter(informerFactory)),
 		vetter.Vetter(danglingroutedestinationhost.NewVetter(informerFactory)),
 		vetter.Vetter(conflictingvirtualservicehost.NewVetter(informerFactory)),
+		vetter.Vetter(authpolicy.NewVetter(informerFactory)),
 	}
 
 	stopCh := make(chan struct{})

--- a/pkg/vetter/authpolicy/README-auth-policy-conflict-namespace.md
+++ b/pkg/vetter/authpolicy/README-auth-policy-conflict-namespace.md
@@ -1,0 +1,97 @@
+# Conflicting Authorization Policies for Namespaces
+
+## Example
+
+Multiple authentication policies `pol-1, pol-2` in namespace `ns-1`
+set the namespace-wide config which will cause unwanted behavior. Update
+policies to remove conflicts.
+
+## Description
+
+Authentication policies are used to define the authentication and mTLS
+requirements that a workload requires to accept traffic. Authentication policies
+can target an entire namespace, a service in that namespace, or a port of that
+service. Policies for more specific targets override less specific policies. 
+
+When two policies have the same target, the behavior is indeterminate; at any
+time you may observe the behavior specified in one policy or another.
+
+
+## Policy Conflicts: Namespaces
+
+If an authentication policy doesn't list any targets, it is targeting the entire
+namespace. The "Conflicting Authorization Policies for Namespace" error
+indicates that you have more than one policy that affects the namepspace-wide
+policy, which will cause indeterminate behavior.
+
+
+### Sample Authentication Policies for Namespaces
+
+In this sample, there is a conflict. There are two policies that apply to the `ns-1` namespace. Neither specifies a target, so they are both targeting
+the namespace-wide policy. The two policies conflict, and you will get unwanted
+behavior - sometimes the first policy will apply, and sometimes the second will
+apply.
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-1
+    namespace: ns-1
+spec:
+    peers:
+    - mls: {}
+```
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-2
+    namespace: ns-1
+spec:
+    peers: 
+    # empty specifies that mTLS is off
+```
+
+In this sample, there are no conflicts. `pol-1` turns mTLS on for
+all services in namespace `ns-2`, and `pol-2` turns it off for
+service `svc-1` in the same namespace. The two policies have overlapping targets,
+but the second policy is more specific than the first, so there is no conflict.
+The second policy will be applied only to the workload for service `svc-1`, while
+the specifications of the policy without a named target will remain in effect
+for all other targets.
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-1
+    namespace: ns-2
+spec:
+    peers: 
+    - mtls: {} 
+```
+
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-2
+    namespace: ns-2
+spec:
+    targets: 
+    - name: svc-1
+    peers: 
+    # empty specifies that mTLS is off
+ 
+```
+
+
+## Suggested Resolution
+
+The error message lists the conflicting policies. Locate the affected policies
+and compare the settings, then remove the conflict/s, perhaps by adjusting the specificity of the target/s. 
+
+

--- a/pkg/vetter/authpolicy/README-auth-policy-conflict-port.md
+++ b/pkg/vetter/authpolicy/README-auth-policy-conflict-port.md
@@ -1,0 +1,95 @@
+# Conflicting Authorization Policies for Ports 
+
+## Example
+
+Multiple authentication policies `pol-1, pol-2` in namespace `ns-1`
+sets the service port config for `svc-1: 8000` which will cause unwanted
+behavior. Update policies to remove conflicts.
+
+## Description
+
+Authentication policies are used to define the authentication and mTLS
+requirements that a workload requires to accept traffic. Authentication policies
+can target an entire namespace, a service in that namespace, or a port of that
+service. Policies for more specific targets override less specific policies. 
+
+When two policies have the same target, the behavior is indeterminate; at any
+time you may observe the behavior specified in one policy or another.
+
+## Policy Conflicts: Ports
+
+If an authentication policy lists a port for a target service, it targets only the workload for that port of the targeted service. The "Conflicting Authorization Policies for Ports" error indicates that you have more than one policy that
+affects the port for the same service, which will cause indeterminate behavior.
+
+
+### Sample Authentication Policies:
+
+In this sample, there is a conflict. There are two policies that target the same port (8001) for service `svc-1` in the namespace `ns-1`. The first policy turns mTLS on for ports 8000 and 8001 while the second policy turns mTLS off for port 8001. The two policies conflict, and you will get unwanted behavior for traffic to port 8001 - sometimes the first policy will apply, and sometimes the second will apply.
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-1
+    namespace: ns-1
+spec:
+    targets: 
+    - name: svc-1
+        ports:
+        - number: 8000
+        - number: 8001
+    peers: 
+        - mtls: {}
+ 
+```
+
+```yaml
+apiVersion: v1alpha1 
+kind: Policy 
+metadata: 
+    name: pol-2
+    namespace: ns-1 
+spec:
+    targets: 
+    - name: svc-1
+        ports:
+        - number: 8001
+    peers: 
+    # empty specifies that mTLS is off
+```
+
+In this sample, there are no conflicts. The first policy turns mTLS on for `svc-1` in namespace `ns-2`, while the second policy turns mTLS off only for port 8000 of the same service. The two policies have overlapping targets due to the scope of the first, but the second policy is more specific so there is no conflict. The second policy will be applied only to `svc-1` workloads for port 8000, while the policy without a port listed will remain in effect for all other ports of that service.
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-1
+    namespace: ns-2
+targets: 
+    - name: svc-1
+    peers: 
+        -mtls: {} 
+```
+
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-2
+    namespace: ns-2
+spec:
+    targets: 
+    - name: svc-1
+        ports:
+        - number: 8000
+    peers: 
+    # empty specifies that mTLS is off
+ 
+```
+
+## Suggested Resolution
+
+The error message lists the conflicting policies. Locate the affected policies
+and compare the settings, then remove the conflict/s, perhaps by adjusting the specificity of the target/s.

--- a/pkg/vetter/authpolicy/README-auth-policy-conflict-service.md
+++ b/pkg/vetter/authpolicy/README-auth-policy-conflict-service.md
@@ -1,0 +1,103 @@
+# Conflicting Authorization Policies for Services 
+
+## Example
+
+Multiple authentication policies `pol-1, pol-2` in namespace `ns-1`
+set the service-wide config for `svc-1` which will cause unwanted behavior.
+Update policies to remove conflicts.
+
+## Description
+
+Authentication policies are used to define the authentication and mTLS
+requirements that a workload requires to accept traffic. Authentication policies
+can target an entire namespace, a service in that namespace, or a port of that
+service. Policies for more specific targets override less specific policies. 
+
+When two policies have the same target, the behavior is indeterminate; at any
+time you may observe the behavior specified in one policy or another.
+
+## Policy Conflicts: Target Services
+
+If an authentication policy lists a target service, but does not list ports for
+that service, it is targeting the whole service. The "Conflicting Authorization
+Policies for Services" error indicates that you have more than one policy that
+affects a service-wide policy, which will cause indeterminate behavior.
+
+
+### Sample Authentication Policies for Target Services
+
+In this sample, there is a conflict. There are two policies for the service
+`svc-1` in namespace `ns-1`. The first policy turns mTLS on for `svc-1` and
+`svc-2`, but the second policy turns mTLS off for `svc-1`. The two
+policies conflict, and you will get unwanted behavior for `svc-1` - sometimes
+the first policy will apply, and sometimes the second will apply.
+
+```yaml
+apiVersion: v1alpha1 
+kind: Policy 
+metadata: 
+    name: pol-1
+    namespace: ns-1
+spec:   
+    targets: 
+    - name: svc-1
+    - name: svc-2
+    peers: 
+        -mtls: {}
+
+```
+
+```yaml
+apiVersion: v1alpha1 
+kind: Policy 
+metadata: 
+    name: pol-2
+    namespace: ns-1 
+spec:   
+    targets: 
+    - name: svc-1
+    peers: 
+    # empty specifies that mTLS is off
+        
+```
+
+In this sample, there are no conflicts. `pol-1` turns mTLS on for
+all services in namespace `ns-2`, while `pol-2` applies only to the
+service `svc-1` in the namespace `ns-2`. The two policies have overlapping targets
+due to the namespace-wide scope of the first, but the second policy is more
+specific than the first so there is no conflict. The second policy will be
+applied only to the workload for service `svc-1`, while the policy without a named
+target will remain in effect for all other targets.
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-1
+    namespace: ns-2
+spec:
+    peers: 
+    - mtls: {} 
+```
+
+```yaml
+apiVersion: v1alpha1
+kind: Policy
+metadata:
+    name: pol-2
+    namespace: ns-2
+spec:
+    targets: 
+    - name: svc-1
+    peers: 
+    # empty specifies that mTLS is off
+ 
+```
+
+
+
+## Suggested Resolution
+
+The error message lists the conflicting policies. Locate the affected policies
+and compare the settings, then remove the conflict/s, perhaps by adjusting the specificity of the target/s.
+

--- a/pkg/vetter/authpolicy/README.md
+++ b/pkg/vetter/authpolicy/README.md
@@ -1,0 +1,18 @@
+# Auth Policy Conflict
+
+Authentication policies are used to define the authentication and mTLS
+requirements that a workload requires to accept traffic. Authentication policies
+can target an entire namespace, a service in that namespace, or a port of that
+service. Policies for more specific targets override less specific policies. 
+
+When two policies have the same target, the behavior is indeterminate; at any
+time you may observe the behavior specified in one policy or another.
+
+## Notes Generated
+
+- [Conflicting Authorization Policies for Ports](README-auth-policy-conflict-port.md)
+- [Conflicting Authorization Policies for
+  Services](README-auth-policy-conflict-service.md)
+- [Conflicting Authorization Policies for
+  Namespaces](README-auth-policy-conflict-namespace.md)
+

--- a/pkg/vetter/authpolicy/authpolicy_suite_test.go
+++ b/pkg/vetter/authpolicy/authpolicy_suite_test.go
@@ -1,0 +1,13 @@
+package authpolicy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuthPolicy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Authpolicy Suite")
+}

--- a/pkg/vetter/authpolicy/authpolicy_test.go
+++ b/pkg/vetter/authpolicy/authpolicy_test.go
@@ -1,0 +1,244 @@
+package authpolicy
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sort"
+
+	aspenv1a1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
+	istiov1alpha1 "istio.io/api/authentication/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func policyNameNoSvc(namespace, polName string) *aspenv1a1.Policy {
+	return &aspenv1a1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      polName,
+			Namespace: namespace,
+		},
+	}
+}
+
+func policyNameOneSvc(namespace, polName, service string) *aspenv1a1.Policy {
+	return &aspenv1a1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      polName,
+		},
+		Spec: aspenv1a1.PolicySpec{
+			Policy: istiov1alpha1.Policy{
+				Targets: []*istiov1alpha1.TargetSelector{
+					&istiov1alpha1.TargetSelector{
+						Name: service,
+					},
+				},
+			},
+		},
+	}
+}
+func policynameMultiSvcs(namespace, polName, svc1, svc2, svc3 string) *aspenv1a1.Policy {
+	return &aspenv1a1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      polName,
+		},
+		Spec: aspenv1a1.PolicySpec{
+			Policy: istiov1alpha1.Policy{
+				Targets: []*istiov1alpha1.TargetSelector{
+					&istiov1alpha1.TargetSelector{
+						Name: svc1,
+					},
+					&istiov1alpha1.TargetSelector{
+						Name: svc2,
+					},
+					&istiov1alpha1.TargetSelector{
+						Name: svc3,
+					},
+				},
+			},
+		},
+	}
+}
+
+func policynameMultiSvcsMultiPorts(namespace string, polName string, svc1 string, svc2 string, port1 uint32, port2 uint32) *aspenv1a1.Policy {
+	return &aspenv1a1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      polName,
+		},
+		Spec: aspenv1a1.PolicySpec{
+			Policy: istiov1alpha1.Policy{
+				Targets: []*istiov1alpha1.TargetSelector{
+					&istiov1alpha1.TargetSelector{
+						Name: svc1,
+						Ports: []*istiov1alpha1.PortSelector{
+							&istiov1alpha1.PortSelector{
+								Port: &istiov1alpha1.PortSelector_Number{Number: port1},
+							},
+						},
+					},
+					&istiov1alpha1.TargetSelector{
+						Name: svc2,
+						Ports: []*istiov1alpha1.PortSelector{
+							&istiov1alpha1.PortSelector{
+								Port: &istiov1alpha1.PortSelector_Number{Number: port2},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getEmptyAuthPolicies() []*aspenv1a1.Policy {
+	return []*aspenv1a1.Policy{}
+}
+
+func sortNotes(notes []*apiv1.Note) []*apiv1.Note {
+	sort.Slice(notes, func(i, j int) bool {
+		if notes[i].Attr["namespace"] != notes[j].Attr["namespace"] {
+			return notes[i].Attr["namespace"] < notes[j].Attr["namespace"]
+		}
+		if notes[i].Attr["policy_names"] != notes[j].Attr["policy_names"] {
+			return notes[i].Attr["policy_names"] < notes[j].Attr["policy_names"]
+		}
+		if notes[i].Attr["target_service"] != notes[j].Attr["target_service"] {
+			return notes[i].Attr["target_service"] < notes[j].Attr["target_service"]
+		}
+		return false
+	})
+	return notes
+}
+
+var _ = Describe("Authentication Policies", func() {
+
+	Describe("Can evaluate the authentication policies for a service", func() {
+		It("returns no notes for empty policies", func() {
+			policies := getEmptyAuthPolicies()
+			notes, err := notesForAuthPolicies(policies)
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(0))
+		})
+		It("returns a note for same namespace, different policynames, no services", func() {
+			pols := []*aspenv1a1.Policy{}
+			a := policyNameNoSvc("namespace1", "name1")
+			b := policyNameNoSvc("namespace1", "name2")
+			pols = append(pols, a, b)
+			notes, err := notesForAuthPolicies(pols)
+
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(1))
+			Expect(notes[0].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[0].Attr["policy_names"]).To(Equal("name1, name2"))
+		})
+		It("returns no note for different namespace, same policynames, no services", func() {
+			pols := []*aspenv1a1.Policy{}
+			a := policyNameNoSvc("namespace1", "name2")
+			b := policyNameNoSvc("namespace2", "name2") //added for noise
+			pols = append(pols, a, b)
+			notes, err := notesForAuthPolicies(pols)
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(0))
+		})
+		It("returns no notes for same namespace, (diff policynames), different servicenames", func() {
+			pols := []*aspenv1a1.Policy{}
+			a := policyNameOneSvc("namespace1", "name1", "service1")
+			b := policyNameOneSvc("namespace1", "name2", "service2")
+			c := policyNameOneSvc("namespace1", "name3", "service3")
+			pols = append(pols, a, b, c)
+			notes, err := notesForAuthPolicies(pols)
+
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(0))
+
+		})
+		It("returns a note for same namespace, (diff policynames), same servicename", func() {
+
+			pols := []*aspenv1a1.Policy{}
+			a := policyNameOneSvc("namespace1", "name1", "service1")
+			b := policyNameOneSvc("namespace1", "name2", "service1")
+			c := policyNameOneSvc("namespace1", "name3", "service3")
+			d := policyNameNoSvc("namespace1", "name4") //added for noise
+			pols = append(pols, a, b, c, d)
+			notes, err := notesForAuthPolicies(pols)
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(1))
+			Expect(notes[0].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[0].Attr["target_service"]).To(Equal("service1"))
+		})
+		It("returns the correct number of notes for policies with target_port", func() {
+			pols := []*aspenv1a1.Policy{}
+			a := policynameMultiSvcsMultiPorts("namespace1", "name1", "service1", "service2", 8000, 8001)
+			b := policynameMultiSvcsMultiPorts("namespace1", "name2", "service1", "service3", 8000, 8003)
+			c := policyNameOneSvc("namespace1", "name2", "service3") //added for noise
+			pols = append(pols, a, b, c)
+			notes, err := notesForAuthPolicies(pols)
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(1))
+			Expect(notes[0].Attr["target_port"]).To(Equal("8000"))
+		})
+		It("returns the correct notes with mixed policies", func() {
+			pols := []*aspenv1a1.Policy{}
+			a := policyNameOneSvc("namespace1", "name1", "service1")
+			b := policynameMultiSvcs("namespace3", "name1", "service1", "service2", "service3")
+			c := policyNameOneSvc("namespace1", "name3", "service3")
+			d := policyNameNoSvc("namespace4", "name2")
+			e := policyNameOneSvc("namespace2", "name2", "service2")
+			f := policyNameNoSvc("namespace2", "name3")
+			g := policynameMultiSvcs("namespace3", "name2", "service1", "service2", "service3")
+			h := policyNameNoSvc("namespace3", "name3")
+			i := policynameMultiSvcsMultiPorts("namespace5", "name1", "service1", "service2", 8002, 8001)
+			j := policyNameOneSvc("namespace1", "name2", "service1")
+			k := policyNameNoSvc("namespace4", "name1")
+			l := policyNameOneSvc("namespace2", "name1", "service3")
+			m := policynameMultiSvcsMultiPorts("namespace5", "name2", "service1", "service3", 8002, 8003)
+
+			pols = append(pols, a, b, c, d, e, f, g, h, i, j, k, l, m)
+			notes, err := notesForAuthPolicies(pols)
+			notes = sortNotes(notes)
+
+			Expect(err).To(BeNil())
+			Expect(notes).To(HaveLen(6))
+
+			Expect(notes[0].Type).To(Equal(authPolicyNoteTypeService))
+			Expect(notes[0].Msg).To(Equal(authPolicyTargetSvcNameMsg))
+			Expect(notes[0].Attr["namespace"]).To(Equal("namespace1"))
+			Expect(notes[0].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[0].Attr["target_service"]).To(Equal("service1"))
+
+			Expect(notes[1].Type).To(Equal(authPolicyNoteTypeService))
+			Expect(notes[1].Msg).To(Equal(authPolicyTargetSvcNameMsg))
+			Expect(notes[1].Attr["namespace"]).To(Equal("namespace3"))
+			Expect(notes[1].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[1].Attr["target_service"]).To(Equal("service1"))
+
+			Expect(notes[2].Type).To(Equal(authPolicyNoteTypeService))
+			Expect(notes[2].Msg).To(Equal(authPolicyTargetSvcNameMsg))
+			Expect(notes[2].Attr["namespace"]).To(Equal("namespace3"))
+			Expect(notes[2].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[2].Attr["target_service"]).To(Equal("service2"))
+
+			Expect(notes[3].Type).To(Equal(authPolicyNoteTypeService))
+			Expect(notes[3].Msg).To(Equal(authPolicyTargetSvcNameMsg))
+			Expect(notes[3].Attr["namespace"]).To(Equal("namespace3"))
+			Expect(notes[3].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[3].Attr["target_service"]).To(Equal("service3"))
+
+			Expect(notes[4].Type).To(Equal(authPolicyNoteTypeNamespace))
+			Expect(notes[4].Msg).To(Equal(authPolicyNamespaceMsg))
+			Expect(notes[4].Attr["namespace"]).To(Equal("namespace4"))
+			Expect(notes[4].Attr["policy_names"]).To(Equal("name1, name2"))
+
+			Expect(notes[5].Type).To(Equal(authPolicyNoteTypePorts))
+			Expect(notes[5].Msg).To(Equal(authPolicySvcPortMsg))
+			Expect(notes[5].Attr["namespace"]).To(Equal("namespace5"))
+			Expect(notes[5].Attr["policy_names"]).To(Equal("name1, name2"))
+			Expect(notes[5].Attr["target_port"]).To(Equal("8002"))
+		})
+
+	})
+
+})

--- a/pkg/vetter/authpolicy/vet.go
+++ b/pkg/vetter/authpolicy/vet.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2017 Aspen Mesh Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package authpolicy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	aspenv1a1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/client/listers/authentication/v1alpha1"
+	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
+	"github.com/aspenmesh/istio-vet/pkg/vetter"
+	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	vetterID                    = "AuthPolicyConflict"
+	authPolicySummary           = "Conflicting authentication policies - ${policy_names}"
+	authPolicyNoteTypeNamespace = "auth-policy-conflict-namespace"
+	authPolicyNoteTypeService   = "auth-policy-conflict-service"
+	authPolicyNoteTypePorts     = "auth-policy-conflict-port"
+	authPolicyNamespaceMsg      = "Multiple authentication policies (${policy_names}) in namespace ${namespace} set the namespace-wide config which will cause unwanted behavior. Update policies to remove conflicts."
+	authPolicyTargetSvcNameMsg  = "Multiple authentication policies (${policy_names}) in namespace ${namespace} set the service-wide config for ${target_service} which will cause unwanted behavior. Update policies to remove conflicts."
+	authPolicySvcPortMsg        = "Multiple authentication policies (${policy_names}) in namespace ${namespace} sets the service port config for ${target_service}:${target_port} which will cause unwanted behavior. Update policies to remove conflicts."
+)
+
+type AuthPolicy struct {
+	polLister v1alpha1.PolicyLister
+}
+
+type PolicyKey struct {
+	Namespace  string
+	TargetName string
+	TargetPort uint32
+}
+
+func notesForAuthPolicies(policies []*aspenv1a1.Policy) ([]*apiv1.Note, error) {
+	notes := []*apiv1.Note{}
+	polKeyMap := map[PolicyKey][]*aspenv1a1.Policy{}
+
+	if len(policies) == 0 {
+		return notes, nil
+	}
+
+	for p := range policies {
+		targets := policies[p].Spec.Policy.Targets
+
+		if len(targets) > 0 {
+			for t := range targets {
+				targetPort := targets[t].Ports
+				if len(targetPort) > 0 {
+					// iterate through each target in the list and make a new key
+					for o := range targetPort {
+						//if there is a port, iterate through targetPort
+						pk := PolicyKey{
+							Namespace:  policies[p].Namespace,
+							TargetName: targets[t].Name,
+							TargetPort: targetPort[o].GetNumber(),
+						}
+						polKeyMap[pk] = append(polKeyMap[pk], policies[p])
+					}
+				} else {
+					//just make the one key if there is no port
+					pk := PolicyKey{
+						Namespace:  policies[p].Namespace,
+						TargetName: targets[t].Name,
+						TargetPort: 0,
+					}
+					polKeyMap[pk] = append(polKeyMap[pk], policies[p])
+				}
+			}
+		} else {
+			pk := PolicyKey{
+				Namespace:  policies[p].Namespace,
+				TargetName: "",
+				TargetPort: 0,
+			}
+			polKeyMap[pk] = append(polKeyMap[pk], policies[p])
+		}
+
+	}
+
+	for k, policyList := range polKeyMap {
+		if len(policyList) > 1 {
+			policyNames := []string{}
+			for p := range policyList {
+				policyNames = append(policyNames, policyList[p].ObjectMeta.Name)
+			}
+			sort.Slice(policyNames, func(i, j int) bool {
+				return policyNames[i] < policyNames[j]
+			})
+
+			if k.TargetPort == 0 && k.TargetName == "" {
+				// policy conflict at namespace level
+				notes = append(notes, &apiv1.Note{
+					Type:    authPolicyNoteTypeNamespace,
+					Summary: authPolicySummary,
+					Msg:     authPolicyNamespaceMsg,
+					Level:   apiv1.NoteLevel_ERROR,
+					Attr: map[string]string{
+						"namespace":    k.Namespace,
+						"policy_names": strings.Join(policyNames, ", ")}})
+
+			} else if k.TargetPort == 0 {
+				// policy conflict of duplicated Service Names
+				notes = append(notes, &apiv1.Note{
+					Type:    authPolicyNoteTypeService,
+					Summary: authPolicySummary,
+					Msg:     authPolicyTargetSvcNameMsg,
+					Level:   apiv1.NoteLevel_ERROR,
+					Attr: map[string]string{
+						"namespace":      k.Namespace,
+						"policy_names":   strings.Join(policyNames, ", "),
+						"target_service": k.TargetName}})
+			} else {
+				// policy conflict at namespace level
+				notes = append(notes, &apiv1.Note{
+					Type:    authPolicyNoteTypePorts,
+					Summary: authPolicySummary,
+					Msg:     authPolicySvcPortMsg,
+					Level:   apiv1.NoteLevel_ERROR,
+					Attr: map[string]string{
+						"namespace":      k.Namespace,
+						"policy_names":   strings.Join(policyNames, ", "),
+						"target_service": k.TargetName,
+						"target_port":    fmt.Sprintf("%v", k.TargetPort)}})
+			}
+		}
+	}
+
+	for i := range notes {
+		notes[i].Id = util.ComputeID(notes[i])
+	}
+
+	return notes, nil
+}
+
+func (a *AuthPolicy) Vet() ([]*apiv1.Note, error) {
+	policies, err := a.polLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	notes, err := notesForAuthPolicies(policies)
+	if err != nil {
+		return nil, err
+	}
+	return notes, nil
+}
+
+// Info returns information about the vetter
+func (a *AuthPolicy) Info() *apiv1.Info {
+	return &apiv1.Info{Id: vetterID, Version: "0.1.0"}
+}
+
+//NewVetter returns "AuthPolicy" which implements Vetter interface
+func NewVetter(factory vetter.ResourceListGetter) *AuthPolicy {
+	return &AuthPolicy{
+		polLister: factory.Istio().Authentication().V1alpha1().Policies().Lister(),
+	}
+}


### PR DESCRIPTION
This Vetter checks all Authorization Policies in a cluster and looks for policies that have the same target. If found, it generates a note about what is conflicting so that users can address the issue(s).