### PR TITLE
Updated list of supported named service ports

### DIFF
--- a/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
+++ b/pkg/vetter/serviceportprefix/README-missing-service-port-prefix.md
@@ -27,9 +27,9 @@ mesh for this service port.  For instance, if your service port named `backend`
 is using an unknown protocol that runs on top of tcp, rename the service port
 to `tcp-backend`.
 
-In version 1.0.0, these protocols are supported: `grpc`, `https`, `http2`,
-`http`, `tcp`, `udp`, `mongo`, `redis`.
+In version 1.1.0, these protocols are supported: `grpc`, `http`, `http2`, `https`,
+`mongo`, `redis`, `tcp`, `tls`, `udp`.
 
 ## See Also
 
-- [Pod and Service Requirements](https://istio.io/docs/setup/kubernetes/spec-requirements/)
+- [Pod and Service Requirements](https://istio.io/docs/setup/kubernetes/prepare/requirements/)

--- a/pkg/vetter/serviceportprefix/README.md
+++ b/pkg/vetter/serviceportprefix/README.md
@@ -11,14 +11,17 @@ recognized prefix or is unnamed, traffic on the port is treated as plain TCP or
 UDP depending on the port protocol.
 
 Port names of the form `<protocol>-<suffix>` or `<protocol`> are allowed for
-the following protocols:
+the following protocols as of Istio 1.1.0:
 
 * http
 * http2
+* https
 * grpc
 * mongo
 * redis
 * tcp
+* tls
+* udp
 
 Note that `tcp` protocol prefix can be used to indicate that the port
 is for TCP protocol. Service ports with protocol type UDP are also excluded

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -112,10 +112,13 @@ type IstioInjectConfig struct {
 var istioSupportedServicePrefix = []string{
 	"http", "http-",
 	"http2", "http2-",
+	"https", "https-",
 	"grpc", "grpc-",
 	"mongo", "mongo-",
 	"redis", "redis-",
-	"tcp", "tcp-"}
+	"tcp", "tcp-",
+	"tls", "tls-",
+	"udp", "udp-"}
 
 var defaultExemptedNamespaces = map[string]bool{
 	"kube-system":  true,


### PR DESCRIPTION
Problem: the list of supported named service port prefixes is outdated (both in code and
documentation), which is causing vet notes to be generated for valid service config.

Solution: the list has been updated to contain all of the supported named port
prefixes as of Istio 1.1.0. The list can be found [here](https://istio.io/docs/setup/kubernetes/prepare/requirements/). The long version of the vet 
note is now more verbose. It contains a list of the unsupported port prefixes 
that were found for a service. Additionally, the documentation was updated to include
the updated list of supported prefixes.

Fixes #46