### PR TITLE
mTLS validation to be skipped on ProxyStatusPorts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8 as builder
+FROM golang:1.9 as builder
 WORKDIR /go/src/github.com/aspenmesh/istio-vet
 
 RUN apt-get update \

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -143,7 +143,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 		glog.Errorf("Failed to retrieve MeshPolicies: %s", err)
 		return nil, err
 	}
-	glog.Infof("Mesh policies: %v", meshPolicyList)
+
 	// (BLaurenB): to account for update to authPolicy.go, this function needs to take a list of mesh policies. Since the mesh policies are handled separately, we still need to determine globalMtls via IsGlobalMtlsEnabled()
 	authPolicies, err := mtlspolicyutil.LoadAuthPolicies(policyList, meshPolicyList)
 	if err != nil {

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -194,7 +194,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 							continue
 						}
 						// Extracts the statusPort from the config.
-						statusPort, errPort := util.ProxyStatusPort(c.Args)
+						statusPort, errPort := util.ProxyStatusPort(c)
 						if errPort == nil && statusPort == probePortNum {
 							glog.Infof("Skipping mTLS check as the sidecar status port is used.")
 							continue

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -177,7 +177,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 					}
 					var intstrptr *intstr.IntOrString = &probePort
 					probePortNum := uint32(intstrptr.IntValue())
-					if probePortNum == 0  {
+					if probePortNum == 0 {
 						// TODO(m-eaton): handle port names by finding the corresponding port
 						// number
 						glog.Errorln("Probe port is a name, skipping to next pod")
@@ -194,8 +194,8 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 							continue
 						}
 						// Extracts the statusPort from the config.
-						statusPort := util.ProxyStatusPort(c)
-						if statusPort == probePortNum {
+						statusPort, errPort := util.ProxyStatusPort(c.Args)
+						if errPort == nil && statusPort == probePortNum {
 							glog.Infof("Skipping mTLS check as the sidecar status port is used.")
 							continue
 						}

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -198,7 +198,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 							continue
 						}
 						// Extracts the statusPort from the config.
-						statusPort := util.StatusPort(c)
+						statusPort := util.ProxyStatusPort(c)
 						if statusPort == probePortNum {
 							glog.Infof("Skipping mTLS check as the sidecar status port is used.")
 							continue

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -193,11 +193,14 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 							glog.Errorln("Error getting pod endpoint, skipping to next pod")
 							continue
 						}
-						// Extracts the statusPort from the config.
-						statusPort, errPort := util.ProxyStatusPort(c)
-						if errPort == nil && statusPort == probePortNum {
-							glog.V(4).Infof("Skipping mTLS check as the sidecar status port is used.")
-							continue
+						// Only special-case status port for sidecar
+						if c.Name == util.IstioProxyContainerName {
+							// Extracts the statusPort from the config.
+							statusPort, errPort := util.ProxyStatusPort(c)
+							if errPort == nil && statusPort == probePortNum {
+								glog.V(4).Infof("Skipping mTLS check as the sidecar status port is used.")
+								continue
+							}
 						}
 						// check to see if mTLS needs to be disabled for the probe
 						if generateNote := isNoteRequiredForMtlsProbe(authPolicies, podEndpoint, probePortNum, globalMtls); generateNote {

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -196,7 +196,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 						// Extracts the statusPort from the config.
 						statusPort, errPort := util.ProxyStatusPort(c)
 						if errPort == nil && statusPort == probePortNum {
-							glog.Infof("Skipping mTLS check as the sidecar status port is used.")
+							glog.V(4).Infof("Skipping mTLS check as the sidecar status port is used.")
 							continue
 						}
 						// check to see if mTLS needs to be disabled for the probe

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -94,7 +94,6 @@ func isNoteRequiredForMtlsProbe(authPolicies *mtlspolicyutil.AuthPolicies, endpo
 	if endpoint == nil {
 		return globalMtls
 	}
-	glog.Infof("Checking mtls probe for probe port %v, pod %v", probePort, endpoint.GetName())
 	// create service
 	var svc mtlspolicyutil.Service = mtlspolicyutil.Service{
 		Name:      endpoint.Name,
@@ -103,17 +102,14 @@ func isNoteRequiredForMtlsProbe(authPolicies *mtlspolicyutil.AuthPolicies, endpo
 	if err != nil {
 		// (m-eaton ?) no policies were found for port, name or namespace, return status of globalMtls
 		// (BLaurenB): err could actually mean conflicting policies, in which case it might need to be handled differently.
-		glog.Infof("TLSByPort error. No policies found for %v, pod %v. Returning globalMtls = %v", probePort, endpoint.GetName(), globalMtls)
 		return globalMtls
 	} else if ap == nil {
 		// (BLaurenB):We didn't find any auth policies that applied, so either
 		// a mesh policy made us choose mtls, or we didn't find anything.
 		// In both cases, globalMtls will be the right mtls state
-		glog.Infof("ap == nil. No policies found for %v, pod %v. Returning globalMtls = %v", probePort, endpoint.GetName(), globalMtls)
 		return globalMtls
 	} else {
 		// (BLaurenB): policy was found, return the mTLS status of the policy
-		glog.Infof("Policy found for %v, pod %v. Returning mtls = %v", probePort, endpoint.GetName(), mtls)
 		return mtls
 	}
 }

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -486,11 +486,11 @@ func ConvertHostnameToFQDN(hostname string, namespace string) (string, error) {
 // Extract status port from the cmd arguments for a given container, or
 //  default that is 15020 (as per Istio 1.1 doc, global.proxy.statusPort
 //  at https://istio.io/docs/reference/config/installation-options-changes/
-func StatusPort(container corev1.Container) uint32 {
+func ProxyStatusPort(container corev1.Container) uint32 {
 	var statusPort uint32 = 15020
 
     for index, key := range container.Args {
-    	// Key we are looking for - hopefully followed by an argument specifying its value.
+    	// Key we are looking for - hopefully followed by an argument specifying its value. If not, return default
     	if key == "--statusPort" && index < len(container.Args) - 1 {
     		// Next entry should be the port...
     		overridePort, err := strconv.ParseUint(container.Args[index+1], 10, 32)

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -63,7 +63,8 @@ const (
 		IstioInitializerConfigMap + "\" not found"
 	initializerDisabledSummary = "Istio initializer is not configured." +
 		" Enable initializer and automatic sidecar injection to use "
-	kubernetesServiceName = "kubernetes"
+	kubernetesServiceName     = "kubernetes"
+	kubernetesProxyStatusPort = "--statusPort"
 )
 
 var istioInjectNamespaceLabel = map[string]string{
@@ -489,12 +490,12 @@ func ConvertHostnameToFQDN(hostname string, namespace string) (string, error) {
 func ProxyStatusPort(container corev1.Container) uint32 {
 	var statusPort uint32 = 15020
 
-    for index, key := range container.Args {
-    	// Key we are looking for - hopefully followed by an argument specifying its value. If not, return default
-    	if key == "--statusPort" && index < len(container.Args) - 1 {
-    		// Next entry should be the port...
-    		overridePort, err := strconv.ParseUint(container.Args[index+1], 10, 32)
-    		if err != nil {
+	for index, key := range container.Args {
+		// Key we are looking for - hopefully followed by an argument specifying its value. If not, return default
+		if key == kubernetesProxyStatusPort && index < len(container.Args)-1 {
+			// Next entry should be the port...
+			overridePort, err := strconv.ParseUint(container.Args[index+1], 10, 32)
+			if err != nil {
 				return statusPort
 			} else {
 				return uint32(overridePort)

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -489,9 +489,9 @@ func ConvertHostnameToFQDN(hostname string, namespace string) (string, error) {
 // Extract status port from the cmd arguments for a given container, or
 //  default that is 15020 (as per Istio 1.1 doc, global.proxy.statusPort
 //  at https://istio.io/docs/reference/config/installation-options-changes/
-func ProxyStatusPort(args []string) (uint32, error) {
+func ProxyStatusPort(container corev1.Container) (uint32, error) {
 	var statusPort uint32 = kubernetesProxyStatusPortDefault
-
+	args := container.Args
 	for index, key := range args {
 		// Key we are looking for - hopefully followed by an argument specifying its value. If not, return default
 		if key == kubernetesProxyStatusPort && index < len(args)-1 {
@@ -499,9 +499,8 @@ func ProxyStatusPort(args []string) (uint32, error) {
 			overridePort, err := strconv.ParseUint(args[index+1], 10, 32)
 			if err != nil {
 				return statusPort, err
-			} else {
-				return uint32(overridePort), nil
 			}
+			return uint32(overridePort), nil
 		}
 	}
 	return statusPort, errors.New("cannot find proxy status port.")

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -485,10 +485,8 @@ func ConvertHostnameToFQDN(hostname string, namespace string) (string, error) {
 	return hostname + "." + namespace + KubernetesDomainSuffix, nil
 }
 
-// ProxyStatusPort
-// Extract status port from the cmd arguments for a given container, or
-//  default that is 15020 (as per Istio 1.1 doc, global.proxy.statusPort
-//  at https://istio.io/docs/reference/config/installation-options-changes/
+// ProxyStatusPort extracts status port from the cmd arguments for a given container,
+// as per Istio 1.1 doc, global.proxy.statusPort https://istio.io/docs/reference/config/installation-options-changes/
 func ProxyStatusPort(container corev1.Container) (uint32, error) {
 	var statusPort uint32 = kubernetesProxyStatusPortDefault
 	args := container.Args

--- a/pkg/vetter/util/util_test.go
+++ b/pkg/vetter/util/util_test.go
@@ -159,48 +159,49 @@ var _ = Describe("Test ProxyStatusPort", func() {
 			"--applicationPorts",
 			"9080",
 		}
-		port, err := ProxyStatusPort(testArgs)
+		container := corev1.Container{Args: testArgs}
+		port, err := ProxyStatusPort(container)
 		Expect(port == 15020)
 		Expect(err == nil)
 
 		// Fail to parse a number value for statusPort
-		testArgs1 := []string{"proxy",
+		container.Args = []string{"proxy",
 			"sidecar",
 			"--domain",
 			"--statusPort",
 			"junk",
 		}
-		port, err = ProxyStatusPort(testArgs1)
+		port, err = ProxyStatusPort(container)
 		Expect(port == kubernetesProxyStatusPortDefault)
 		Expect(err != nil)
 
 		// Status port is not the default
-		testArgs = []string{"proxy",
+		container.Args = []string{"proxy",
 			"sidecar",
 			"--domain",
 			"--statusPort",
 			"12345",
 		}
-		port, err = ProxyStatusPort(testArgs)
+		port, err = ProxyStatusPort(container)
 		Expect(port == 12345)
 		Expect(err == nil)
 
 		// No statusPort defined
-		testArgs = []string{"proxy",
+		container.Args = []string{"proxy",
 			"sidecar",
 			"--domain",
 		}
-		port, err = ProxyStatusPort(testArgs)
+		port, err = ProxyStatusPort(container)
 		Expect(port == kubernetesProxyStatusPortDefault)
 		Expect(err != nil)
 
 		// statusPort defined but not specified!
-		testArgs = []string{"proxy",
+		container.Args = []string{"proxy",
 			"sidecar",
 			"--domain",
 			"--statusPort",
 		}
-		port, err = ProxyStatusPort(testArgs)
+		port, err = ProxyStatusPort(container)
 		Expect(port == kubernetesProxyStatusPortDefault)
 		Expect(err != nil)
 	})

--- a/pkg/vetter/util/util_test.go
+++ b/pkg/vetter/util/util_test.go
@@ -126,8 +126,7 @@ var _ = Describe("Converting configmap to SidecarInjectionSpec", func() {
 var _ = Describe("Test ProxyStatusPort", func() {
 	It("Finds an override that is not 15020", func() {
 
-		// Actual list from a kubectl get pods ratings-v1-76f4c9765f-n8w45 -o yaml call (so what we should have
-		//  at run time.
+		// Typical argument list from a kubectl get pods
 		testArgs := []string{"proxy",
 			"sidecar",
 			"--domain",


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/164964011 - we should not flag mTLS issues with the proxy status port.