### PR TITLE
Removed unused ConfigMap lister argument

### DIFF
--- a/pkg/vetter/applabel/vet.go
+++ b/pkg/vetter/applabel/vet.go
@@ -37,7 +37,6 @@ const (
 type AppLabel struct {
 	info      apiv1.Info
 	nsLister  v1.NamespaceLister
-	cmLister  v1.ConfigMapLister
 	podLister v1.PodLister
 }
 
@@ -45,7 +44,7 @@ type AppLabel struct {
 func (m *AppLabel) Vet() ([]*apiv1.Note, error) {
 	notes := []*apiv1.Note{}
 
-	pods, err := util.ListPodsInMesh(m.nsLister, m.cmLister, m.podLister)
+	pods, err := util.ListPodsInMesh(m.nsLister, m.podLister)
 	if err != nil {
 		if n := util.IstioInitializerDisabledNote(err.Error(), vetterID,
 			missingAppLabelNoteType); n != nil {
@@ -82,7 +81,6 @@ func (m *AppLabel) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *AppLabel {
 	return &AppLabel{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
-		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
 	}
 }

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -42,7 +42,6 @@ const (
 type VsHost struct {
 	nsLister v1.NamespaceLister
 	vsLister netv1alpha3.VirtualServiceLister
-	cmLister v1.ConfigMapLister
 }
 type hostAndGateway struct {
 	gateway  string
@@ -116,7 +115,7 @@ func populateVirtualServiceMap(hg hostAndGateway, vs *v1alpha3.VirtualService, v
 
 // Vet returns the list of generated notes
 func (v *VsHost) Vet() ([]*apiv1.Note, error) {
-	virtualServices, err := util.ListVirtualServicesInMesh(v.nsLister, v.cmLister, v.vsLister)
+	virtualServices, err := util.ListVirtualServicesInMesh(v.nsLister, v.vsLister)
 	if err != nil {
 		fmt.Printf("Error occurred retrieving VirtualServices: %s\n", err.Error())
 		return nil, err
@@ -138,7 +137,6 @@ func (v *VsHost) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *VsHost {
 	return &VsHost{
 		nsLister: factory.K8s().Core().V1().Namespaces().Lister(),
-		cmLister: factory.K8s().Core().V1().ConfigMaps().Lister(),
 		vsLister: factory.Istio().Networking().V1alpha3().VirtualServices().Lister(),
 	}
 }

--- a/pkg/vetter/danglingroutedestinationhost/vet.go
+++ b/pkg/vetter/danglingroutedestinationhost/vet.go
@@ -44,7 +44,6 @@ const (
 // DanglingRouteDestinationHost implements Vetter interface
 type DanglingRouteDestinationHost struct {
 	nsLister  v1.NamespaceLister
-	cmLister  v1.ConfigMapLister
 	svcLister v1.ServiceLister
 	vsLister  netv1alpha3.VirtualServiceLister
 }
@@ -108,12 +107,12 @@ func createDanglingRouteHostNotes(svcs []*corev1.Service,
 
 // Vet returns the list of generated notes
 func (r *DanglingRouteDestinationHost) Vet() ([]*apiv1.Note, error) {
-	svcs, err := util.ListServicesInMesh(r.nsLister, r.cmLister, r.svcLister)
+	svcs, err := util.ListServicesInMesh(r.nsLister, r.svcLister)
 	if err != nil {
 		return nil, err
 	}
 
-	vsList, err := util.ListVirtualServicesInMesh(r.nsLister, r.cmLister, r.vsLister)
+	vsList, err := util.ListVirtualServicesInMesh(r.nsLister, r.vsLister)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +130,6 @@ func (r *DanglingRouteDestinationHost) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *DanglingRouteDestinationHost {
 	return &DanglingRouteDestinationHost{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
-		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		svcLister: factory.K8s().Core().V1().Services().Lister(),
 		vsLister:  factory.Istio().Networking().V1alpha3().VirtualServices().Lister(),
 	}

--- a/pkg/vetter/meshversion/vet.go
+++ b/pkg/vetter/meshversion/vet.go
@@ -129,7 +129,7 @@ func (m *MeshVersion) vetInjectedImages() ([]*apiv1.Note, error) {
 		return notes, nil
 	}
 
-	pods, err := util.ListPodsInMesh(m.nsLister, m.cmLister, m.podLister)
+	pods, err := util.ListPodsInMesh(m.nsLister, m.podLister)
 	if err != nil {
 		// If err != nil when getting pod data, the lower-level error has already
 		// been logged and handled.

--- a/pkg/vetter/mtlsprobes/vet.go
+++ b/pkg/vetter/mtlsprobes/vet.go
@@ -50,7 +50,6 @@ const (
 type MtlsProbes struct {
 	podLister v1.PodLister
 	nsLister  v1.NamespaceLister
-	cmLister  v1.ConfigMapLister
 	epLister  v1.EndpointsLister
 	apLister  authv1alpha1.PolicyLister
 	mpLister  authv1alpha1.MeshPolicyLister
@@ -117,7 +116,7 @@ func isNoteRequiredForMtlsProbe(authPolicies *mtlspolicyutil.AuthPolicies, endpo
 // Vet returns the list of generated notes
 func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 	var notes []*apiv1.Note
-	pods, err := util.ListPodsInMesh(m.nsLister, m.cmLister, m.podLister)
+	pods, err := util.ListPodsInMesh(m.nsLister, m.podLister)
 	if err != nil {
 		if n := util.IstioInitializerDisabledNote(err.Error(), vetterID,
 			mtlsProbesNoteType); n != nil {
@@ -152,7 +151,7 @@ func (m *MtlsProbes) Vet() ([]*apiv1.Note, error) {
 		return nil, err
 	}
 	// get list of endpoints
-	endpointsList, err := util.ListEndpointsInMesh(m.nsLister, m.cmLister, m.epLister)
+	endpointsList, err := util.ListEndpointsInMesh(m.nsLister, m.epLister)
 	if err != nil {
 		glog.Errorln("unable to retrieve list of endpoints in the mesh")
 		return nil, err
@@ -244,7 +243,6 @@ func (m *MtlsProbes) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *MtlsProbes {
 	return &MtlsProbes{
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
-		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
 		epLister:  factory.K8s().Core().V1().Endpoints().Lister(),
 		apLister:  factory.Istio().Authentication().V1alpha1().Policies().Lister(),

--- a/pkg/vetter/serviceassociation/vet.go
+++ b/pkg/vetter/serviceassociation/vet.go
@@ -41,7 +41,6 @@ const (
 // SvcAssociation implements Vetter interface
 type SvcAssociation struct {
 	nsLister  v1.NamespaceLister
-	cmLister  v1.ConfigMapLister
 	epLister  v1.EndpointsLister
 	podLister v1.PodLister
 }
@@ -81,7 +80,7 @@ func createEndpointMap(e []*corev1.Endpoints, podLister v1.PodLister) map[string
 // Vet returns the list of generated notes
 func (m *SvcAssociation) Vet() ([]*apiv1.Note, error) {
 	notes := []*apiv1.Note{}
-	endpoints, err := util.ListEndpointsInMesh(m.nsLister, m.cmLister, m.epLister)
+	endpoints, err := util.ListEndpointsInMesh(m.nsLister, m.epLister)
 	if err != nil {
 		if n := util.IstioInitializerDisabledNote(err.Error(), vetterID,
 			multipleServiceAssociationNoteType); n != nil {
@@ -122,7 +121,6 @@ func (m *SvcAssociation) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *SvcAssociation {
 	return &SvcAssociation{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
-		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		epLister:  factory.K8s().Core().V1().Endpoints().Lister(),
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
 	}

--- a/pkg/vetter/serviceportprefix/vet.go
+++ b/pkg/vetter/serviceportprefix/vet.go
@@ -40,14 +40,13 @@ const (
 // SvcPortPrefix implements Vetter interface
 type SvcPortPrefix struct {
 	nsLister  v1.NamespaceLister
-	cmLister  v1.ConfigMapLister
 	svcLister v1.ServiceLister
 }
 
 // Vet returns the list of generated notes
 func (m *SvcPortPrefix) Vet() ([]*apiv1.Note, error) {
 	notes := []*apiv1.Note{}
-	services, err := util.ListServicesInMesh(m.nsLister, m.cmLister, m.svcLister)
+	services, err := util.ListServicesInMesh(m.nsLister, m.svcLister)
 	if err != nil {
 		if n := util.IstioInitializerDisabledNote(err.Error(), vetterID,
 			servicePortPrefixNoteType); n != nil {
@@ -93,7 +92,6 @@ func (m *SvcPortPrefix) Info() *apiv1.Info {
 func NewVetter(factory vetter.ResourceListGetter) *SvcPortPrefix {
 	return &SvcPortPrefix{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
-		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		svcLister: factory.K8s().Core().V1().Services().Lister(),
 	}
 }

--- a/pkg/vetter/util/util.go
+++ b/pkg/vetter/util/util.go
@@ -263,7 +263,7 @@ func InitImage(n string, s corev1.PodSpec) (string, error) {
 // ListNamespacesInMesh returns the list of Namespaces in the mesh.
 // Namespaces with label "istio-inject=enabled" are considered in
 // the mesh.
-func ListNamespacesInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister) ([]*corev1.Namespace, error) {
+func ListNamespacesInMesh(nsLister v1.NamespaceLister) ([]*corev1.Namespace, error) {
 	ns, err := nsLister.List(labels.Set(istioInjectNamespaceLabel).AsSelector())
 	if err != nil {
 		glog.Error("Failed to retrieve namespaces: ", err)
@@ -275,9 +275,9 @@ func ListNamespacesInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapList
 // ListPodsInMesh returns the list of Pods in the mesh.
 // Pods in Namespaces returned by ListNamespacesInMesh with sidecar
 // injected as determined by SidecarInjected are considered in the mesh.
-func ListPodsInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister, podLister v1.PodLister) ([]*corev1.Pod, error) {
+func ListPodsInMesh(nsLister v1.NamespaceLister, podLister v1.PodLister) ([]*corev1.Pod, error) {
 	pods := []*corev1.Pod{}
-	ns, err := ListNamespacesInMesh(nsLister, cmLister)
+	ns, err := ListNamespacesInMesh(nsLister)
 	if err != nil {
 		return nil, err
 	}
@@ -298,9 +298,9 @@ func ListPodsInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister, po
 
 // ListServicesInMesh returns the list of Services in the mesh.
 // Services in Namespaces returned by ListNamespacesInMesh are considered in the mesh.
-func ListServicesInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister, svcLister v1.ServiceLister) ([]*corev1.Service, error) {
+func ListServicesInMesh(nsLister v1.NamespaceLister, svcLister v1.ServiceLister) ([]*corev1.Service, error) {
 	services := []*corev1.Service{}
-	ns, err := ListNamespacesInMesh(nsLister, cmLister)
+	ns, err := ListNamespacesInMesh(nsLister)
 	if err != nil {
 		return nil, err
 	}
@@ -339,9 +339,9 @@ func IsEndpointInMesh(ea *corev1.EndpointAddress, podLister v1.PodLister) bool {
 
 // ListEndpointsInMesh returns the list of Endpoints in the mesh.
 // Endpoints in Namespaces returned by ListNamespacesInMesh are considered in the mesh.
-func ListEndpointsInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister, epLister v1.EndpointsLister) ([]*corev1.Endpoints, error) {
+func ListEndpointsInMesh(nsLister v1.NamespaceLister, epLister v1.EndpointsLister) ([]*corev1.Endpoints, error) {
 	endpoints := []*corev1.Endpoints{}
-	ns, err := ListNamespacesInMesh(nsLister, cmLister)
+	ns, err := ListNamespacesInMesh(nsLister)
 	if err != nil {
 		return nil, err
 	}
@@ -367,10 +367,10 @@ func ComputeID(n *apiv1.Note) string {
 }
 
 // ListVirtualServices returns a list of VirtualService resources in the mesh.
-func ListVirtualServicesInMesh(nsLister v1.NamespaceLister, cmLister v1.ConfigMapLister,
+func ListVirtualServicesInMesh(nsLister v1.NamespaceLister,
 	vsLister netv1alpha3.VirtualServiceLister) ([]*v1alpha3.VirtualService, error) {
 	virtualServices := []*v1alpha3.VirtualService{}
-	ns, err := ListNamespacesInMesh(nsLister, cmLister)
+	ns, err := ListNamespacesInMesh(nsLister)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Problem: Vets had to pass in a ConfigMapLister, even though the underlying shared utility was not doing anything with it. 

Solution: Removed it from the shared utility and corresponding vetters that was using it.