### PR TITLE
Make conflictingvirtualservicehost merging aware.

### DIFF
--- a/pkg/vetter/conflictingvirtualservicehost/README-host-in-multiple-vs.md
+++ b/pkg/vetter/conflictingvirtualservicehost/README-host-in-multiple-vs.md
@@ -2,7 +2,7 @@
 
 ## Example
 
-ERROR: The VirtualServices vs1.default, vs2.default define the same host (*) and gateway (gateway-1). A Virtual Service must have a unique combination of host and gateway. Consider updating the VirtualServices to have unique hostname and gateway.
+ERROR: The VirtualServices vs1.default, vs2.default with routes /foo prefix /foo exact define the same host (*) and conflict. A Virtual Service defining the same host must not conflict. Consider updating the VirtualServices to have unique hostname or update the rules so they do not conflict.
 
 ## Description
 
@@ -47,7 +47,8 @@ The FQDNs assigned to the hosts below would be reviews.foo.svc.cluster.local and
 
 ### Sample 2
 
-The FQDNs assigned to the hosts in the following example would both be reviews.default.svc.cluster.local, and both specify the same gateway.
+The FQDNs assigned to the hosts in the following example would both be reviews.default.svc.cluster.local,
+and their matching rules conflict (since /service1 is a prefix of /service1/start).
 This is not allowed, and will cause indeterminate routing behavior in your
 cluster.
 
@@ -62,7 +63,10 @@ cluster.
     - reviews
     gateways:
     - my-gateway-1
-    ...
+    http:
+      - match:
+        - uri:
+          prefix: /service1
 ---
   apiVersion: networking.istio.io/v1alpha3
   kind: VirtualService
@@ -74,15 +78,21 @@ cluster.
     - reviews
     gateways:
     - my-gateway-1
-    ...
+    http:
+      - match:
+        - uri:
+          prefix: /service1/start
 ```
 
 The following note will be generated:
 
 ```shell
-Summary: "Multiple VirtualServices define the same host (reviews) and gateway (my-gateway-1)"
+Summary: "Multiple VirtualServices define the same host (reviews) and conflict"
 
-Message: "ERROR: The VirtualServices vs3.default, vs4.default  define the same host (reviews) and gateway (my-gateway-1). A VirtualService must have a unique combination of host and gateway. Consider updating the VirtualService(s) to have unique hostname and gateway."
+Message: "ERROR: The VirtualServices vs3.default, vs4.default  define the same host (reviews)
+matching uris (/service1 prefix /service1/start prefix) conflict. VirtualServices defining the same
+host must not conflict. Considuring updating the VirtualServices to have unique hostnames or update the
+rules so they do not conflict."
 ```
 See [Suggested Resolution](#suggested-resolution) (1) below for an example of how to fix this by
 changing the hostnames and gateways to be unique.
@@ -126,7 +136,7 @@ routing behavior in your cluster.
     http:
     - match:
       - uri:
-          prefix: /mail
+          exact: /search
       route:
       - destination:
           host: mail.foo.svc.cluster.local
@@ -139,9 +149,9 @@ Summary: "Multiple VirtualServices define the same host (google.com) and
 gateway (my-gateway-1)"
 
 Message: "ERROR: The VirtualServices vs5.foo, vs6.foo  define the same host
-(google.com) and gateway (my-gateway-1). A VirtualService must have a unique
-combination of host and gateway. Consider updating the VirtualService(s) to
-have unique hostname and gateway."
+matching uris (/search prefix /search exact) conflict. VirtualServices defining the same
+host must not conflict. Considuring updating the VirtualServices to have unique hostnames or update the
+rules so they do not conflict."
 ```
 See [Suggested Resolution](#suggested-resolution) (2) below for an example of
 how to fix this by merging the rules of the two VirtualService resources into
@@ -153,8 +163,7 @@ You can do one of these two things:
 
 1. **Make the hostnames unique.** Change the hostnames defined in the
    conflicting VirtualServices to be unique. The following VirtualServices have
-   unique hostnames "reviews" and "ratings" or use the host with different
-   gateways. Either option would resolve the issue for Sample 2 above.
+   unique hostnames "reviews" and "ratings".
 
 ```yaml
     apiVersion: networking.istio.io/v1alpha3
@@ -180,61 +189,4 @@ You can do one of these two things:
       hosts:
       - ratings
       ...
-```
-
-```yaml
-    apiVersion: networking.istio.io/v1alpha3
-    kind: VirtualService
-    metadata:
-      name: vs3
-      namespace: default
-    spec:
-      gateways:
-      - my-gateway-1
-      hosts:
-      - reviews
-      ...
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: VirtualService
-    metadata:
-      name: vs4
-      namespace: default
-    spec:
-      gateways:
-      - my-gateway-two
-      hosts:
-      - reviews
-      ...
-```
-
-2. **Merge the conflicting VirtualServices.** Merge the rules defined in the
-   conflicting VirtualServices into one VirtualService resource. The following
-VirtualService would resolve the issue for Sample 3 above, as the rules are
-merged and only a single VirtualService with the "google.com" hostname remains.
-
-```yaml
-    apiVersion: networking.istio.io/v1alpha3
-    kind: VirtualService
-    metadata:
-      name: vs5
-      namespace: foo
-    spec:
-      gateways:
-      - my-gateway-1
-      hosts:
-      - google.com
-      http:
-      - match:
-        - uri:
-            prefix: /search
-        route:
-        - destination:
-            host: search.foo.svc.cluster.local
-      - match:
-        - uri:
-            prefix: /mail
-        route:
-        - destination:
-            host: mail.foo.svc.cluster.local
 ```

--- a/pkg/vetter/conflictingvirtualservicehost/README-host-in-multiple-vs.md
+++ b/pkg/vetter/conflictingvirtualservicehost/README-host-in-multiple-vs.md
@@ -2,7 +2,7 @@
 
 ## Example
 
-ERROR: The VirtualServices vs1.default, vs2.default with routes /foo prefix /foo exact define the same host (*) and conflict. A Virtual Service defining the same host must not conflict. Consider updating the VirtualServices to have unique hostname or update the rules so they do not conflict.
+ERROR: The VirtualServices vs1.default, vs2.default with routes /foo prefix /foo exact define the same host (*) and conflict. A Virtual Service defining the same host must not conflict. Consider updating the VirtualServices to have unique hostnames or update the rules so they do not conflict.
 
 ## Description
 
@@ -89,8 +89,8 @@ The following note will be generated:
 ```shell
 Summary: "Multiple VirtualServices define the same host (reviews) and conflict"
 
-Message: "ERROR: The VirtualServices vs3.default, vs4.default  define the same host (reviews)
-matching uris (/service1 prefix /service1/start prefix) conflict. VirtualServices defining the same
+Message: "ERROR: The VirtualServices vs3.default, vs4.default define the same host (reviews)
+matching uris /service1 prefix /service1/start prefix conflict. VirtualServices defining the same
 host must not conflict. Considuring updating the VirtualServices to have unique hostnames or update the
 rules so they do not conflict."
 ```

--- a/pkg/vetter/conflictingvirtualservicehost/README.md
+++ b/pkg/vetter/conflictingvirtualservicehost/README.md
@@ -3,20 +3,21 @@
 The `conflictingvirtualservicehost` vetter inspects the [Virtual
 Service(s)](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/)
 resources in your cluster and generates errors if more than one of them define
-the same hostname and gateway. When multiple VirtualServices define the same hostname and gateway, it
-can cause indeterminite routing behavior in your cluster.
+the same hostname and the same route. When multiple VirtualServices
+define the same hostname, Pilot will try to merge those virtual
+services, which can happen in an indeterminite order and cause unexpected
+behavior in your cluster. Additionally, if two virtual services define the
+same hostname and at least one of them uses sidecar routing (i.e., not
+attached to a specific gateway), merging cannot occur.
 
-Istio requires that each VirtualService uses a unique combination of hostname
-and gateway. Short hostnames (those that do not contain a '\.') are converted to
-fully qualified domain names (FQDN) that include the namespace where the
-VirtualService resource is defined, so short hostnames are allowed to be
-repeated so long as they are defined in separate namespaces. Converting short
+Istio requires that each VirtualService uses a unique combination of hostname,
+ gateway, and route. Short hostnames (those that do not contain a '\.') are
+ converted to fully qualified domain names (FQDN) that include the namespace
+ where the VirtualService resource is defined, so short hostnames are allowed to
+ be repeated so long as they are defined in separate namespaces. Converting short
 names to FQDN does not apply to hostnames that include a wildcard '\*' prefix,
 IP addresses, or web addresses. These must be unique regardless of the namespace
 in which they are defined.
-
-It is recommended that you make the hostname and gateway unique per VirtualService, or merge the conflicting
-VirtualServices into one VirtualService resource.
 
 ## Notes Generated
 

--- a/pkg/vetter/conflictingvirtualservicehost/README.md
+++ b/pkg/vetter/conflictingvirtualservicehost/README.md
@@ -10,8 +10,8 @@ behavior in your cluster. Additionally, if two virtual services define the
 same hostname and at least one of them uses sidecar routing (i.e., not
 attached to a specific gateway), merging cannot occur.
 
-Istio requires that each VirtualService uses a unique combination of hostname,
- gateway, and route. Short hostnames (those that do not contain a '\.') are
+Istio requires that each VirtualService uses a unique combination of hostname
+  and route. Short hostnames (those that do not contain a '\.') are
  converted to fully qualified domain names (FQDN) that include the namespace
  where the VirtualService resource is defined, so short hostnames are allowed to
  be repeated so long as they are defined in separate namespaces. Converting short

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -249,6 +249,7 @@ func addRouteToMergedVsTree(trie *routeTrie, match *istiov1alpha3.StringMatch, v
 	}
 }
 
+// Traverse the trie depth-first and add any conflicts to the list of conflicting rules.
 func conflictingSubroutes(trie *routeTrie, rRule routeRule, conflictingRules [][]routeRule) ([][]routeRule, error) {
 	for _, rule := range trie.routeRules {
 		if c, err := conflict(rRule, rule); err != nil {
@@ -283,6 +284,9 @@ func conflictingSubroutes(trie *routeTrie, rRule routeRule, conflictingRules [][
 	}
 	return conflictingRules, nil
 }
+
+// Add conflicts for the same route to the list of conflicting rules. Traverse the trie depth-first.
+// Rules for a given route will always conflict if they are not in the same virtual service.
 func addConflictsForSameRoute(trie *routeTrie, conflictingRules [][]routeRule) [][]routeRule {
 	routeRules := trie.routeRules
 	for i := 0; i < len(routeRules)-1; i++ {

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -340,9 +340,6 @@ func conflict(ancestorRule routeRule, descendantRule routeRule) (bool, error) {
 		return true, nil
 	}
 	if ancestorRule.ruleType == regex {
-		// Throwing away the error makes me feel gross but this regex should be validated before we get to it.
-		// Even if it is invalid, giving the wrong answer isn't the biggest deal since regex validation is
-		// outside the scope of this vetter.
 		matched, err := regexp.MatchString(ancestorRule.route, descendantRule.route)
 		return matched, err
 	}
@@ -350,7 +347,7 @@ func conflict(ancestorRule routeRule, descendantRule routeRule) (bool, error) {
 	if ancestorRule.route == descendantRule.route {
 		return true, nil
 	}
-	// Fix this.
+
 	return true, fmt.Errorf("Could not determine whether these %v and %v are in conflict! This "+
 		"is the result of a bug in the vetter.", ancestorRule, descendantRule)
 }

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -50,29 +50,10 @@ const (
 	regex
 )
 
-// We need a type that is a Note with the keys
-// that occur in this note "unfolded" (since
-// we want to use that type as a key in a map,
-// but the Attr field in Note is a map and hence
-// unhashable)
-type conflictingVsNote struct {
-	Type    string
-	Summary string
-	Msg     string
-	Level   apiv1.NoteLevel
-	vsNames string
-	host    string
-	routes  string
-}
-
 // VsHost implements Vetter interface
 type VsHost struct {
 	nsLister v1.NamespaceLister
 	vsLister netv1alpha3.VirtualServiceLister
-}
-type hostAndGateway struct {
-	gateway  string
-	hostname string
 }
 
 type routeRule struct {
@@ -87,8 +68,6 @@ type routeTrie struct {
 	regexs     []routeRule
 	routeRules []routeRule
 }
-
-type VirtualSvcByHostAndGateway map[hostAndGateway][]*v1alpha3.VirtualService
 
 func asString(rrType routeRuleType) string {
 	if rrType == prefix {
@@ -360,14 +339,6 @@ func getRouteRuleFromMatch(match *istiov1alpha3.StringMatch, vs *v1alpha3.Virtua
 		return routeRule{ruleType: regex, route: route, vsName: vs.Name, namespace: vs.Namespace}
 	}
 	return routeRule{}
-}
-
-func populateVirtualServiceMap(hg hostAndGateway, vs *v1alpha3.VirtualService, vsByHostAndGateway VirtualSvcByHostAndGateway) {
-	if _, ok := vsByHostAndGateway[hg]; !ok {
-		vsByHostAndGateway[hg] = []*v1alpha3.VirtualService{vs}
-	} else {
-		vsByHostAndGateway[hg] = append(vsByHostAndGateway[hg], vs)
-	}
 }
 
 // Vet returns the list of generated notes

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -320,38 +320,23 @@ func addConflictsForSameRoute(trie *routeTrie, conflictingRules [][]routeRule) [
 //   This happens after we've encountered our first "real" route rule. This should
 //   always return false.
 //
-// case 2: ancestorRule and descendantRule are identically equal
-//   Since rules don't conflict with themselves, this should also be false.
-
-// case 3: The routes for ancestorRule and descendantRule are the same, but they're different rules.
-//   This should be a conflict.
-//
-// case 4: There is exactly one regex in the trie
+// case 2: There is exactly one regex in the trie
 //   For reasons elaborated elsewhere, there will only ever be one regex in
 //   a given trie. Given how the trie is traversed, the regex will always be
 //   the ancestorRule; it can never be the descendantRule.
 //
-// case 5: The ancestorRule is a prefix rule
+// case 3: The ancestorRule is a prefix rule
 //   Note that the only relevant case here is when the route for descendantRule is a
-//   strict subroute of ancestorRule (because case 3 handles the case when routes are equal).
-//   In practice, this should always result in a conflict because of how the trie is traversed.
+//   strict subroute of ancestorRule (because rules for the same route are handled in a different
+//   code path). In practice, this should always result in a conflict because of how the trie is traversed.
 //
-//  case 6: The ancestorRule is an exact rule
+//  case 4: The ancestorRule is an exact rule
 //    Since the only relevant case is when the route for descendantRule is a strict
-//    subroute of ancestorRule (same as case 5), this should always be false in practice.
+//    subroute of ancestorRule (same as case 3), this should always be false in practice.
 func conflict(ancestorRule routeRule, descendantRule routeRule) (bool, error) {
 	// The "(routeRule{})" needs to be in parenthesis; I'm not sure why.
 	if ancestorRule == (routeRule{}) {
 		return false, nil
-	}
-
-	// If the rules are identically equal, no merge conflicts occur.
-	if ancestorRule == descendantRule {
-		return false, nil
-	}
-
-	if ancestorRule.route == descendantRule.route {
-		return true, nil
 	}
 
 	if ancestorRule.ruleType == regex {

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -38,7 +38,7 @@ const (
 	vsHostSummary  = "Multiple VirtualServices define the same host (${host}) and conflict"
 	vsHostMsg      = "The VirtualServices ${vs_names} matching uris ${routes}" +
 		" define the same host (${host}) and conflict. VirtualServices defining the same host must" +
-		" not conflict. Consider updating the VirtualServices to have uniques hostname or " +
+		" not conflict. Consider updating the VirtualServices to have unique hostnames or " +
 		"update the rules so they do not conflict."
 
 	sidecarRoutingSummary = "Multiple VirtualServices define the same host and ${vs_name} uses sidecar routing."

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -135,13 +135,11 @@ func CreateVirtualServiceNotes(virtualServices []*v1alpha3.VirtualService) ([]*a
 
 	// create vet notes
 
-	// We only want to report the unique hosts for a given conflict.
-	// This should be thought of as a hash map from notes to a set of
-	// host names.
 	uniqueNotes := map[conflictingVsNote]struct{}{}
 	notes := []*apiv1.Note{}
 	for host, vsList := range vsByHost {
 		if len(vsList) > 1 {
+
 			conflictingRules, err := conflictingVirtualServices(vsList)
 			if err != nil {
 				return notes, err
@@ -165,7 +163,7 @@ func CreateVirtualServiceNotes(virtualServices []*v1alpha3.VirtualService) ([]*a
 			}
 		}
 	}
-	for k, v := range uniqueNotes {
+	for k, _ := range uniqueNotes {
 		notes = append(notes, unwrapNote(k))
 	}
 	for i := range notes {

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -171,6 +171,29 @@ func conflictingVirtualServices(vsList []*v1alpha3.VirtualService) ([][]routeRul
 
 // Create a trie representing the routes with their corresponding match rules
 // from a list of virtual services.
+//
+// The nodes of the trie can be thought of as the components of a route with
+// arrays/slices containing the match type of the route rules for that node
+// if there are any.
+//
+// For example, consider the route rules:
+//   /foo/bar exact
+//   /foo/bar prefix
+//   /bar exact
+//   /bar/baz prefix
+//
+// Then the trie could be thought of like
+//
+//                         o (dummy node)
+//                        / \
+//                       /   \
+//                      /     \
+//                     /       \
+//                (/foo, [])  (/bar, [exact])
+//                   /          \
+//                  /            \
+//                 /              \
+// (/foo/bar, [prefix, exact])    (/bar/baz, [prefix])
 func buildMergedVirtualServiceTrie(vsList []*v1alpha3.VirtualService) *routeTrie {
 	subRoutes := make(map[string]*routeTrie)
 	trie := &routeTrie{subRoutes: subRoutes, regexs: []routeRule{}, routeRules: []routeRule{}}

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -36,10 +36,10 @@ const (
 	vetterID       = "ConflictingVirtualServiceHost"
 	vsHostNoteType = "host-in-multiple-vs"
 	vsHostSummary  = "Multiple VirtualServices define the same host (${host}) and conflict"
-	vsHostMsg      = "The VirtualServices ${vs_names} with routes ${routes}" +
-		" define the same host (${host}) and conflict. A VirtualServices defining the same host must" +
-		" not conflict. Consider updating the VirtualServices to have a unique hostname or " +
-		"remove one of the conflicting rules."
+	vsHostMsg      = "The VirtualServices ${vs_names} matching uris ${routes}" +
+		" define the same host (${host}) and conflict. VirtualServices defining the same host must" +
+		" not conflict. Consider updating the VirtualServices to have uniques hostname or " +
+		"update the rules so they do not conflict."
 
 	sidecarRoutingSummary = "Multiple VirtualServices define the same host and ${vs_name} uses sidecar routing."
 	sidecarRoutingMsg     = "The VirtualService ${vs_name} uses sidecar routing (no gateway is explicitly attached)." +

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -263,6 +263,7 @@ func addRouteToMergedVsTree(trie *routeTrie, match *istiov1alpha3.StringMatch, v
 		return
 	}
 
+	// Trim trailing slashes
 	if strings.HasSuffix("/", rRule.route) {
 		rRule.route = strings.TrimSuffix(rRule.route, "/")
 	}
@@ -302,6 +303,7 @@ func conflictingSubroutes(trie *routeTrie, rRule routeRule, conflictingRules [][
 	}
 
 	for _, descendant := range trie.subRoutes {
+		// There are now route rules for this node, recurse down with the same rule.
 		if len(descendant.routeRules) == 0 {
 			if c, err := conflictingSubroutes(descendant, rRule, conflictingRules); err != nil {
 				return conflictingRules, err

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -99,7 +99,18 @@ func CreateVirtualServiceNotes(virtualServices []*v1alpha3.VirtualService) ([]*a
 	}
 
 	// create vet notes
+	notes, err := addConflictingRulesNotes(vsByHost)
 
+	if err != nil {
+		return []*apiv1.Note{}, err
+	}
+	for i := range notes {
+		notes[i].Id = util.ComputeID(notes[i])
+	}
+	return notes, nil
+}
+
+func addConflictingRulesNotes(vsByHost map[string][]*v1alpha3.VirtualService) ([]*apiv1.Note, error) {
 	notes := []*apiv1.Note{}
 	for host, vsList := range vsByHost {
 		if len(vsList) > 1 {
@@ -129,9 +140,7 @@ func CreateVirtualServiceNotes(virtualServices []*v1alpha3.VirtualService) ([]*a
 			}
 		}
 	}
-	for i := range notes {
-		notes[i].Id = util.ComputeID(notes[i])
-	}
+
 	return notes, nil
 }
 
@@ -260,7 +269,7 @@ func addConflictsForSameRoute(trie *routeTrie, conflictingRules [][]routeRule) [
 			// however, this can be finnicky enough that I'm leaving it out
 			// of the first pass and we can add it in later if it is a cause
 			// of confusion.
-			if routeRules[i].vsName != routeRules[j].vsName &&
+			if routeRules[i].vsName != routeRules[j].vsName ||
 				routeRules[i].namespace != routeRules[j].namespace {
 				conflictingRules = append(conflictingRules, []routeRule{routeRules[i], routeRules[j]})
 			}

--- a/pkg/vetter/conflictingvirtualservicehost/vet_test.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 			Expect(vsNotes).To(HaveLen(0))
 		})
 
-		FIt("Generates a note when routes exist in two virtual services with different initial components", func() {
+		It("Generates a note when routes exist in two virtual services with different initial components", func() {
 			Vs1.Spec.Http = []*istiov1alpha3.HTTPRoute{&prefixRoute2Levelsbar}
 			Vs2.Spec.Http = []*istiov1alpha3.HTTPRoute{&exactRoute3Levels, &exactRoute3Levelsbar}
 			vsList := []*v1alpha3.VirtualService{Vs1, Vs2}

--- a/pkg/vetter/conflictingvirtualservicehost/vet_test.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet_test.go
@@ -333,130 +333,107 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 			Expect(vsNotes).To(HaveLen(0))
 		})
 
-		It("Generates multiple notes with the correct number of VirtualService names when there are multiple conflicts found", func() {
+		FIt("Generates multiple notes with the correct number of VirtualService names when there are multiple conflicts found", func() {
 			Vs4.Spec.Http = []*istiov1alpha3.HTTPRoute{&exactRoute, &prefixRoute}
 			Vs8.Spec.Http = []*istiov1alpha3.HTTPRoute{&prefixRoute2Levels, &exactRoute}
 			Vs11.Spec.Http = []*istiov1alpha3.HTTPRoute{&prefixRoute}
 			vsList := []*v1alpha3.VirtualService{Vs4, Vs8, Vs11}
 			vsNotes, err := CreateVirtualServiceNotes(vsList)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vsNotes).To(HaveLen(11))
+			Expect(vsNotes).To(HaveLen(8))
 			expectedNote1 := &apiv1.Note{
 				Type:    vsHostNoteType,
-				Summary: sidecarRoutingSummary,
-				Msg:     sidecarRoutingMsg,
+				Summary: vsHostSummary,
+				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_name":  "Vs4",
-					"vs_names": "Vs4, Vs8, Vs11",
+					"vs_names": "Vs4.bar, Vs8.bar",
+					"host":     "foo.com",
+					"routes":   "/foo prefix /foo/bar prefix",
 				},
 			}
+
 			expectedNote2 := &apiv1.Note{
 				Type:    vsHostNoteType,
-				Summary: sidecarRoutingSummary,
-				Msg:     sidecarRoutingMsg,
+				Summary: vsHostSummary,
+				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_name":  "Vs8",
-					"vs_names": "Vs4, Vs8, Vs11",
+					"vs_names": "Vs4.bar, Vs8.bar",
+					"host":     "foo.com",
+					"routes":   "/foo prefix /foo exact",
 				},
 			}
+
 			expectedNote3 := &apiv1.Note{
 				Type:    vsHostNoteType,
-				Summary: sidecarRoutingSummary,
-				Msg:     sidecarRoutingMsg,
+				Summary: vsHostSummary,
+				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_name":  "Vs11",
-					"vs_names": "Vs4, Vs8, Vs11",
+					"host":     "foo.com",
+					"routes":   "/foo exact /foo exact",
+					"vs_names": "Vs4.bar, Vs8.bar",
 				},
 			}
+
 			expectedNote4 := &apiv1.Note{
 				Type:    vsHostNoteType,
 				Summary: vsHostSummary,
 				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_names": "Vs1.bar, Vs2.bar",
-					"host":     "host2.bar.svc.cluster.local",
-					"routes":   "/foo exact /foo exact",
+					"vs_names": "Vs8.bar, Vs11.bar",
+					"host":     "foo.com",
+					"routes":   "/foo exact /foo prefix",
 				},
 			}
+
 			expectedNote5 := &apiv1.Note{
 				Type:    vsHostNoteType,
 				Summary: vsHostSummary,
 				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_names": "Vs1.bar, Vs2.bar",
-					"host":     "host2.bar.svc.cluster.local",
-					"routes":   "/foo prefix /foo exact",
+					"vs_names": "Vs11.bar, Vs8.bar",
+					"host":     "foo.com",
+					"routes":   "/foo prefix /foo/bar prefix",
 				},
 			}
+
 			expectedNote6 := &apiv1.Note{
 				Type:    vsHostNoteType,
 				Summary: vsHostSummary,
 				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_names": "Vs2.bar, Vs11.bar",
-					"host":     "host2.bar.svc.cluster.local",
-					"routes":   "/foo exact /foo prefix",
+					"vs_names": "Vs4.bar, Vs11.bar",
+					"host":     "foo.com",
+					"routes":   "/foo prefix /foo prefix",
 				},
 			}
+
 			expectedNote7 := &apiv1.Note{
 				Type:    vsHostNoteType,
 				Summary: vsHostSummary,
 				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"routes":   "/foo prefix /foo/bar prefix",
-					"vs_names": "Vs1.bar, Vs2.bar",
-					"host":     "host2.bar.svc.cluster.local",
+					"host":     "foo.com",
+					"routes":   "/foo exact /foo prefix",
+					"vs_names": "Vs4.bar, Vs11.bar",
 				},
 			}
+
 			expectedNote8 := &apiv1.Note{
 				Type:    vsHostNoteType,
 				Summary: vsHostSummary,
 				Msg:     vsHostMsg,
 				Level:   apiv1.NoteLevel_ERROR,
 				Attr: map[string]string{
-					"vs_names": "Vs11.bar, Vs2.bar",
-					"host":     "host2.bar.svc.cluster.local",
-					"routes":   "/foo prefix /foo/bar prefix",
-				},
-			}
-			expectedNote9 := &apiv1.Note{
-				Type:    vsHostNoteType,
-				Summary: vsHostSummary,
-				Msg:     vsHostMsg,
-				Level:   apiv1.NoteLevel_ERROR,
-				Attr: map[string]string{
+					"vs_names": "Vs4.bar, Vs4.bar",
+					"host":     "foo.com",
 					"routes":   "/foo exact /foo prefix",
-					"vs_names": "Vs1.bar, Vs1.bar",
-					"host":     "host2.bar.svc.cluster.local",
-				},
-			}
-			expectedNote10 := &apiv1.Note{
-				Type:    vsHostNoteType,
-				Summary: vsHostSummary,
-				Msg:     vsHostMsg,
-				Level:   apiv1.NoteLevel_ERROR,
-				Attr: map[string]string{
-					"vs_names": "Vs1.bar, Vs11.bar",
-					"host":     "host2.bar.svc.cluster.local",
-					"routes":   "/foo exact /foo prefix",
-				},
-			}
-			expectedNote11 := &apiv1.Note{
-				Type:    vsHostNoteType,
-				Summary: vsHostSummary,
-				Msg:     vsHostMsg,
-				Level:   apiv1.NoteLevel_ERROR,
-				Attr: map[string]string{
-					"routes":   "/foo prefix /foo prefix",
-					"vs_names": "Vs1.bar, Vs11.bar",
-					"host":     "host2.bar.svc.cluster.local",
 				},
 			}
 			expectedNote1.Id = util.ComputeID(expectedNote1)
@@ -467,27 +444,15 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 			expectedNote6.Id = util.ComputeID(expectedNote6)
 			expectedNote7.Id = util.ComputeID(expectedNote7)
 			expectedNote8.Id = util.ComputeID(expectedNote8)
-			expectedNote9.Id = util.ComputeID(expectedNote9)
-			expectedNote10.Id = util.ComputeID(expectedNote10)
-			expectedNote11.Id = util.ComputeID(expectedNote11)
 			sort.Slice(vsNotes, func(i, j int) bool {
 				return vsNotes[i].Attr["host"] > vsNotes[j].Attr["host"]
 			})
 			expecteds := []*apiv1.Note{expectedNote1, expectedNote2, expectedNote3, expectedNote4, expectedNote5,
-				expectedNote6, expectedNote7, expectedNote8, expectedNote9, expectedNote10, expectedNote11,
+				expectedNote6, expectedNote7, expectedNote8,
 			}
 			for _, note := range vsNotes {
-				found := false
-				for _, expected := range expecteds {
-					if note == expected {
-						found = true
-					}
-					if !found {
-						Expect(false)
-					}
-				}
+				Expect(expecteds).To(ContainElement(note))
 			}
-			Expect(true)
 		})
 	})
 })

--- a/pkg/vetter/conflictingvirtualservicehost/vet_test.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 			Expect(vsNotes).To(HaveLen(0))
 		})
 
-		It("Generates a note when routes exist in two virtual services with different initial components", func() {
+		FIt("Generates a note when routes exist in two virtual services with different initial components", func() {
 			Vs1.Spec.Http = []*istiov1alpha3.HTTPRoute{&prefixRoute2Levelsbar}
 			Vs2.Spec.Http = []*istiov1alpha3.HTTPRoute{&exactRoute3Levels, &exactRoute3Levelsbar}
 			vsList := []*v1alpha3.VirtualService{Vs1, Vs2}

--- a/pkg/vetter/conflictingvirtualservicehost/vet_test.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet_test.go
@@ -33,10 +33,10 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 		namespace := "bar"
 		vsHostNoteType := "host-in-multiple-vs"
 		vsHostSummary := "Multiple VirtualServices define the same host (${host}) and conflict"
-		vsHostMsg := "The VirtualServices ${vs_names} with routes ${routes}" +
-			" define the same host (${host}) and conflict. A VirtualServices defining the same host must" +
-			" not conflict. Consider updating the VirtualServices to have a unique hostname or " +
-			"remove one of the conflicting rules."
+		vsHostMsg := "The VirtualServices ${vs_names} matching uris ${routes}" +
+			" define the same host (${host}) and conflict. VirtualServices defining the same host must" +
+			" not conflict. Consider updating the VirtualServices to have unique hostnames or " +
+			"update the rules so they do not conflict."
 		var Vs1 *v1alpha3.VirtualService = &v1alpha3.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "Vs1",

--- a/pkg/vetter/conflictingvirtualservicehost/vet_test.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet_test.go
@@ -449,5 +449,17 @@ var _ = Describe("Conflicting Virtual Service Host Vet Notes", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vsNotes).To(BeEmpty())
 		})
+
+		// This test can be deleted/return a conflict if we want to report
+		// on conflicts within the same VS.
+		It("Does not warn if two routes conflict but are in the same VS", func() {
+			Vs1.Spec.Http = []*istiov1alpha3.HTTPRoute{&prefixRoute, &prefixRoute2Levels}
+			vsList := []*v1alpha3.VirtualService{Vs1}
+
+			vsNotes, err := CreateVirtualServiceNotes(vsList)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsNotes).To(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
According to the
docs (https://istio.io/docs/ops/best-practices/traffic-management/)
and issue #73, Pilot will merge virtual services that are bound to a
gateway if they have the same route and host as opposed to before
where that would be an error. Update this vetter to be aware of this situation.