### PR TITLE
Remove ref to JWT vetter that was removed from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,6 @@ It includes:
     This vetter generates warnings if the same host is defined in multiple
     virtual service resources.
 
-  * [invalidserviceforjwtpolicy](https://github.com/aspenmesh/istio-vet/blob/master/pkg/vetter/invalidserviceforjwtpolicy/README.md) -
-    This vetter generates notes if the target service in the JWT enabled
-    Authentication  Policy is invalid.
-
 More details about vetters can be found in the individual vetters package
 documentation.
 


### PR DESCRIPTION
Accidentally left reference to removed vetter in README; fixed.