### PR TITLE
Add constructors for vetters using Listers.

### DIFF
--- a/pkg/vetter/applabel/vet.go
+++ b/pkg/vetter/applabel/vet.go
@@ -22,7 +22,7 @@ import (
 	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
 	"github.com/aspenmesh/istio-vet/pkg/vetter"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -82,5 +82,12 @@ func NewVetter(factory vetter.ResourceListGetter) *AppLabel {
 	return &AppLabel{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
+	}
+}
+
+func NewVetterFromListers(nsLister v1.NamespaceLister, podLister v1.PodLister) *AppLabel {
+	return &AppLabel{
+		nsLister:  nsLister,
+		podLister: podLister,
 	}
 }

--- a/pkg/vetter/conflictingvirtualservicehost/vet.go
+++ b/pkg/vetter/conflictingvirtualservicehost/vet.go
@@ -436,3 +436,10 @@ func NewVetter(factory vetter.ResourceListGetter) *VsHost {
 		vsLister: factory.Istio().Networking().V1beta1().VirtualServices().Lister(),
 	}
 }
+
+func NewVetterFromListers(nsLister v1.NamespaceLister, vsLister istioNetListers.VirtualServiceLister) *VsHost {
+	return &VsHost{
+		nsLister: nsLister,
+		vsLister: vsLister,
+	}
+}

--- a/pkg/vetter/danglingroutedestinationhost/vet.go
+++ b/pkg/vetter/danglingroutedestinationhost/vet.go
@@ -135,3 +135,11 @@ func NewVetter(factory vetter.ResourceListGetter) *DanglingRouteDestinationHost 
 		vsLister:  factory.Istio().Networking().V1beta1().VirtualServices().Lister(),
 	}
 }
+
+func NewVetterFromListers(nsLister v1.NamespaceLister, svcLister v1.ServiceLister, vsLister istioNetListers.VirtualServiceLister) *DanglingRouteDestinationHost {
+	return &DanglingRouteDestinationHost{
+		nsLister:  nsLister,
+		svcLister: svcLister,
+		vsLister:  vsLister,
+	}
+}

--- a/pkg/vetter/meshversion/vet.go
+++ b/pkg/vetter/meshversion/vet.go
@@ -20,13 +20,14 @@ package meshversion
 
 import (
 	"errors"
+
 	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
 	"github.com/aspenmesh/istio-vet/pkg/vetter"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
 
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -160,5 +161,13 @@ func NewVetter(factory vetter.ResourceListGetter) *MeshVersion {
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
 		cmLister:  factory.K8s().Core().V1().ConfigMaps().Lister(),
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
+	}
+}
+
+func NewVetterFromListers(podLister v1.PodLister, cmLister v1.ConfigMapLister, nsLister v1.NamespaceLister) *MeshVersion {
+	return &MeshVersion{
+		podLister: podLister,
+		cmLister:  cmLister,
+		nsLister:  nsLister,
 	}
 }

--- a/pkg/vetter/podsinmesh/vet.go
+++ b/pkg/vetter/podsinmesh/vet.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -104,5 +104,12 @@ func NewVetter(factory vetter.ResourceListGetter) *MeshStats {
 	return &MeshStats{
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
+	}
+}
+
+func NewVetterFromListers(podLister v1.PodLister, nsLister v1.NamespaceLister) *MeshStats {
+	return &MeshStats{
+		podLister: podLister,
+		nsLister:  nsLister,
 	}
 }

--- a/pkg/vetter/serviceassociation/vet.go
+++ b/pkg/vetter/serviceassociation/vet.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aspenmesh/istio-vet/pkg/vetter"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -123,5 +123,13 @@ func NewVetter(factory vetter.ResourceListGetter) *SvcAssociation {
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
 		epLister:  factory.K8s().Core().V1().Endpoints().Lister(),
 		podLister: factory.K8s().Core().V1().Pods().Lister(),
+	}
+}
+
+func NewVetterFromListers(nsLister v1.NamespaceLister, epLister v1.EndpointsLister, podLister v1.PodLister) *SvcAssociation {
+	return &SvcAssociation{
+		nsLister:  nsLister,
+		epLister:  epLister,
+		podLister: podLister,
 	}
 }

--- a/pkg/vetter/serviceportprefix/vet.go
+++ b/pkg/vetter/serviceportprefix/vet.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "github.com/aspenmesh/istio-vet/api/v1"
 	"github.com/aspenmesh/istio-vet/pkg/vetter"
 	"github.com/aspenmesh/istio-vet/pkg/vetter/util"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -93,5 +93,12 @@ func NewVetter(factory vetter.ResourceListGetter) *SvcPortPrefix {
 	return &SvcPortPrefix{
 		nsLister:  factory.K8s().Core().V1().Namespaces().Lister(),
 		svcLister: factory.K8s().Core().V1().Services().Lister(),
+	}
+}
+
+func NewVetterFromListers(nsLister v1.NamespaceLister, svcLister v1.ServiceLister) *SvcPortPrefix {
+	return &SvcPortPrefix{
+		nsLister:  nsLister,
+		svcLister: svcLister,
 	}
 }


### PR DESCRIPTION
In some versions of Istio (especially prevelant in Istio 1.5 and
lower), the CRDs set "PreserveUnknownFields" to true. When using the
stock Istio client-go informers, this can prevent the informer caches
to synce when you start the informers.

We work around this by generating our own informer factories and
caches to handle these kinds of errors (while preserving the Listers from Istio's client-go).

Because of different package locations, our generated
informers do not satisfy the same interfaces as Istio's
client-go so we can't use the NewVetter function.

This commit creates a new function to add an alternate way of creating
a vetter using listers instead of a factory.