### PR TITLE
Update download location for protocol buffers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L -O \
-    https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip \
+    https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip \
  && echo 'e4b51de1b75813e62d6ecdde582efa798586e09b5beaebfb866ae7c9eaadace4 protoc-3.4.0-linux-x86_64.zip' | sha256sum -c - \
  && mkdir -p /usr/local \
  && unzip protoc-3.4.0-linux-x86_64.zip -d /usr/local


### PR DESCRIPTION
## Description

The [`protoc` download link](https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip) we were using broke briefly, due to a redirect issue.

We may not have been downloading from the correct repo.  Oddly enough, google/protobuf does not appear to be the official protobuf repo, rather a redirect to the official repo:

https://github.com/google/protobuf

It looks like the official repo is here:
https://developers.google.com/protocol-buffers
https://github.com/protocolbuffers/protobuf

Rather than relying on a redirect, we should download from the official repo.

## Story or Bug

N/A
